### PR TITLE
redis: Support eval_ro, evalsha_ro

### DIFF
--- a/source/extensions/filters/network/common/redis/supported_commands.h
+++ b/source/extensions/filters/network/common/redis/supported_commands.h
@@ -39,7 +39,7 @@ struct SupportedCommands {
    * @return commands which hash on the fourth argument
    */
   static const absl::flat_hash_set<std::string>& evalCommands() {
-    CONSTRUCT_ON_FIRST_USE(absl::flat_hash_set<std::string>, "eval", "evalsha");
+    CONSTRUCT_ON_FIRST_USE(absl::flat_hash_set<std::string>, "eval", "evalsha", "eval_ro", "evalsha_ro");
   }
 
   /**


### PR DESCRIPTION
Support eval_ro, evalsha_ro in redis proxy