### PR TITLE
[CPLAT-8549] Improve access log : record trace sampled

### DIFF
--- a/source/common/formatter/http_specific_formatter.cc
+++ b/source/common/formatter/http_specific_formatter.cc
@@ -182,6 +182,37 @@ TraceIDFormatter::formatWithContext(const HttpFormatterContext& context,
   return trace_id;
 }
 
+namespace {
+// Determines if the request is being traced based on stream info.
+// This is equivalent to TracerUtility::shouldTraceRequest but inlined
+// to avoid dependency on tracer_lib.
+bool isTraced(const StreamInfo::StreamInfo& stream_info) {
+  if (stream_info.healthCheck()) {
+    return false;
+  }
+  switch (stream_info.traceReason()) {
+  case Tracing::Reason::ClientForced:
+  case Tracing::Reason::ServiceForced:
+  case Tracing::Reason::Sampling:
+    return true;
+  default:
+    return false;
+  }
+}
+} // namespace
+
+absl::optional<std::string>
+TraceSampledFormatter::formatWithContext(const HttpFormatterContext&,
+                                         const StreamInfo::StreamInfo& stream_info) const {
+  return isTraced(stream_info) ? "true" : "false";
+}
+
+Protobuf::Value
+TraceSampledFormatter::formatValueWithContext(const HttpFormatterContext&,
+                                              const StreamInfo::StreamInfo& stream_info) const {
+  return ValueUtil::stringValue(isTraced(stream_info) ? "true" : "false");
+}
+
 GrpcStatusFormatter::Format GrpcStatusFormatter::parseFormat(absl::string_view format) {
   if (format.empty() || format == "CAMEL_STRING") {
     return GrpcStatusFormatter::CamelString;
@@ -453,6 +484,11 @@ BuiltInHttpCommandParser::getKnownFormatters() {
         {CommandSyntaxChecker::COMMAND_ONLY,
          [](absl::string_view, absl::optional<size_t>) {
            return std::make_unique<TraceIDFormatter>();
+         }}},
+       {"TRACE_SAMPLED",
+        {CommandSyntaxChecker::COMMAND_ONLY,
+         [](absl::string_view, absl::optional<size_t>) {
+           return std::make_unique<TraceSampledFormatter>();
          }}},
        {"QUERY_PARAM",
         {CommandSyntaxChecker::PARAMS_REQUIRED | CommandSyntaxChecker::LENGTH_ALLOWED,

--- a/source/common/formatter/http_specific_formatter.h
+++ b/source/common/formatter/http_specific_formatter.h
@@ -149,6 +149,20 @@ public:
                                          const StreamInfo::StreamInfo& stream_info) const override;
 };
 
+/**
+ * FormatterProvider for trace sampled status.
+ * Uses Envoy's internal tracing decision (stream_info.traceReason()).
+ * Works at trace origin (e.g., Istio Ingress Gateway) where no incoming traceparent header exists.
+ */
+class TraceSampledFormatter : public FormatterProvider {
+public:
+  absl::optional<std::string>
+  formatWithContext(const HttpFormatterContext& context,
+                    const StreamInfo::StreamInfo& stream_info) const override;
+  Protobuf::Value formatValueWithContext(const HttpFormatterContext& context,
+                                         const StreamInfo::StreamInfo& stream_info) const override;
+};
+
 class GrpcStatusFormatter : public FormatterProvider, HeaderFormatter {
 public:
   enum Format {

--- a/test/common/formatter/substitution_formatter_test.cc
+++ b/test/common/formatter/substitution_formatter_test.cc
@@ -2900,6 +2900,50 @@ TEST(SubstitutionFormatterTest, TraceIDFormatter) {
   }
 }
 
+TEST(SubstitutionFormatterTest, TraceSampledFormatter) {
+  StreamInfo::MockStreamInfo stream_info;
+  Http::TestRequestHeaderMapImpl request_header{};
+  Http::TestResponseHeaderMapImpl response_header{};
+  Http::TestResponseTrailerMapImpl response_trailer{};
+  std::string body;
+  HttpFormatterContext formatter_context(&request_header, &response_header, &response_trailer,
+                                         body);
+  TraceSampledFormatter formatter{};
+
+  // Test traced=true cases: Sampling, ClientForced, ServiceForced
+  {
+    EXPECT_CALL(stream_info, healthCheck()).WillRepeatedly(Return(false));
+    EXPECT_CALL(stream_info, traceReason()).WillRepeatedly(Return(Tracing::Reason::Sampling));
+    EXPECT_EQ("true", formatter.formatWithContext(formatter_context, stream_info));
+    EXPECT_THAT(formatter.formatValueWithContext(formatter_context, stream_info),
+                ProtoEq(ValueUtil::stringValue("true")));
+  }
+  {
+    EXPECT_CALL(stream_info, healthCheck()).WillOnce(Return(false));
+    EXPECT_CALL(stream_info, traceReason()).WillOnce(Return(Tracing::Reason::ClientForced));
+    EXPECT_EQ("true", formatter.formatWithContext(formatter_context, stream_info));
+  }
+  {
+    EXPECT_CALL(stream_info, healthCheck()).WillOnce(Return(false));
+    EXPECT_CALL(stream_info, traceReason()).WillOnce(Return(Tracing::Reason::ServiceForced));
+    EXPECT_EQ("true", formatter.formatWithContext(formatter_context, stream_info));
+  }
+
+  // Test traced=false cases: NotTraceable, HealthCheck
+  {
+    EXPECT_CALL(stream_info, healthCheck()).WillRepeatedly(Return(false));
+    EXPECT_CALL(stream_info, traceReason()).WillRepeatedly(Return(Tracing::Reason::NotTraceable));
+    EXPECT_EQ("false", formatter.formatWithContext(formatter_context, stream_info));
+    EXPECT_THAT(formatter.formatValueWithContext(formatter_context, stream_info),
+                ProtoEq(ValueUtil::stringValue("false")));
+  }
+  {
+    // HealthCheck requests should return false regardless of traceReason
+    EXPECT_CALL(stream_info, healthCheck()).WillOnce(Return(true));
+    EXPECT_EQ("false", formatter.formatWithContext(formatter_context, stream_info));
+  }
+}
+
 /**
  * Populate a metadata object with the following test data:
  * "com.test": {"test_key":"test_value","test_obj":{"inner_key":"inner_value"}}


### PR DESCRIPTION
##  Summary

  Add a new access log formatter that extracts the sampled flag from the traceparent header. Use  `%TRACEPARENT_SAMPLED%` command in access log format.

##  Changes

  - New Formatter: TraceparentSampledFormatter class
    - Parses W3C Trace Context traceparent header
    - Extracts LSB (sampled bit) from trace-flags and returns "true" or "false"
    - Supports both Request and Response headers

##  Technical Details

  - traceparent header format: {version}-{trace-id}-{parent-id}-{trace-flags}
  - Validates minimum 55 characters (version(2) + trace_id(32) + span_id(16) + flags(2) +
  delimiters)
  - Parses last 2 hex characters; returns sampled if LSB is 1

##  Test Plan

  - sampled=01 → returns "true"
  - sampled=00 → returns "false"
  - Missing header → returns nullopt
  - Invalid format (insufficient length) → returns nullopt
  - Invalid hex value → returns nullopt
  - Response header support
  - formatValueWithContext tests

  Usage Example
```yaml
  access_log:
    - name: envoy.access_loggers.file
      typed_config:
        "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
        path: /dev/stdout
        log_format:
          text_format: "[%START_TIME%] %TRACEPARENT_SAMPLED%\n"
```