### PR TITLE
CPLAT-10838: Update to Envoy v1.38.3 with Sendbird custom patches

### DIFF
--- a/api/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
+++ b/api/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
@@ -34,7 +34,7 @@ message RedisProxy {
       "envoy.config.filter.network.redis_proxy.v2.RedisProxy";
 
   // Redis connection pool settings.
-  // [#next-free-field: 11]
+  // [#next-free-field: 13]
   message ConnPoolSettings {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.config.filter.network.redis_proxy.v2.RedisProxy.ConnPoolSettings";
@@ -152,6 +152,37 @@ message RedisProxy {
     // storm to busy redis server. This config is a protection to rate limit reconnection rate.
     // If not set, there will be no rate limiting on the reconnection.
     ConnectionRateLimit connection_rate_limit = 10;
+
+    // Enable per-shard statistics for tracking hot shard usage. When enabled, the following
+    // statistics will be emitted per upstream host (shard):
+    //
+    // * ``upstream_rq_total``: Total requests to this shard
+    // * ``upstream_rq_success``: Successful requests to this shard
+    // * ``upstream_rq_failure``: Failed requests to this shard
+    // * ``upstream_rq_active``: Active requests to this shard (gauge)
+    //
+    // The statistics will be emitted under the scope:
+    // ``cluster.<cluster_name>.shard.<host_address>.*``
+    //
+    // .. note::
+    //   Enabling this option may significantly increase metric cardinality in large clusters
+    //   with many shards. Use with caution in production environments.
+    bool enable_per_shard_stats = 11;
+
+    // Enable per-shard latency histogram for tracking request latency per upstream host (shard).
+    // When enabled, the following histogram will be emitted per shard:
+    //
+    // * ``upstream_rq_time``: Request latency histogram in microseconds
+    //
+    // The histogram will be emitted under the scope:
+    // ``cluster.<cluster_name>.shard.<host_address>.upstream_rq_time``
+    //
+    // This option requires ``enable_per_shard_stats`` to be enabled.
+    //
+    // .. note::
+    //   Enabling this option may significantly increase metric cardinality in large clusters
+    //   with many shards. Use with caution in production environments.
+    bool enable_per_shard_latency_stats = 12;
   }
 
   message PrefixRoutes {

--- a/docs/root/intro/arch_overview/other_protocols/redis.rst
+++ b/docs/root/intro/arch_overview/other_protocols/redis.rst
@@ -254,6 +254,7 @@ For details on each command's usage see the official
   SISMEMBER, Set
   SMEMBERS, Set
   SPOP, Set
+  SPUBLISH Pubsub
   SRANDMEMBER, Set
   SREM, Set
   SCAN, Generic
@@ -264,8 +265,11 @@ For details on each command's usage see the official
   SINTERSTORE, Set
   SMISMEMBER, Set
   SMOVE, Set
+  SSUBSCRIBE Pubsub
+  SUBSCRIBE, Pubsub
   SUNION, Set
   SUNIONSTORE, Set
+  SUNSUBSCRIBE Pubsub
   WATCH, String
   UNWATCH, String
   ZADD, Sorted Set

--- a/source/common/formatter/http_specific_formatter.cc
+++ b/source/common/formatter/http_specific_formatter.cc
@@ -211,6 +211,37 @@ absl::optional<std::string> SpanIDFormatter::format(const Context& context,
   return span_id;
 }
 
+namespace {
+// Determines if the request is being traced based on stream info.
+// This is equivalent to TracerUtility::shouldTraceRequest but inlined
+// to avoid dependency on tracer_lib.
+bool isTraced(const StreamInfo::StreamInfo& stream_info) {
+  if (stream_info.healthCheck()) {
+    return false;
+  }
+  switch (stream_info.traceReason()) {
+  case Tracing::Reason::ClientForced:
+  case Tracing::Reason::ServiceForced:
+  case Tracing::Reason::Sampling:
+    return true;
+  default:
+    return false;
+  }
+}
+} // namespace
+
+absl::optional<std::string>
+TraceSampledFormatter::formatWithContext(const HttpFormatterContext&,
+                                         const StreamInfo::StreamInfo& stream_info) const {
+  return isTraced(stream_info) ? "true" : "false";
+}
+
+Protobuf::Value
+TraceSampledFormatter::formatValueWithContext(const HttpFormatterContext&,
+                                              const StreamInfo::StreamInfo& stream_info) const {
+  return ValueUtil::stringValue(isTraced(stream_info) ? "true" : "false");
+}
+
 GrpcStatusFormatter::Format GrpcStatusFormatter::parseFormat(absl::string_view format) {
   if (format.empty() || format == "CAMEL_STRING") {
     return GrpcStatusFormatter::CamelString;
@@ -563,6 +594,11 @@ BuiltInHttpCommandParser::getKnownFormatters() {
         {CommandSyntaxChecker::COMMAND_ONLY,
          [](absl::string_view, absl::optional<size_t>) {
            return std::make_unique<SpanIDFormatter>();
+         }}},
+       {"TRACE_SAMPLED",
+        {CommandSyntaxChecker::COMMAND_ONLY,
+         [](absl::string_view, absl::optional<size_t>) {
+           return std::make_unique<TraceSampledFormatter>();
          }}},
        {"QUERY_PARAM",
         {CommandSyntaxChecker::PARAMS_REQUIRED | CommandSyntaxChecker::LENGTH_ALLOWED,

--- a/source/common/formatter/http_specific_formatter.cc
+++ b/source/common/formatter/http_specific_formatter.cc
@@ -231,14 +231,14 @@ bool isTraced(const StreamInfo::StreamInfo& stream_info) {
 } // namespace
 
 absl::optional<std::string>
-TraceSampledFormatter::formatWithContext(const HttpFormatterContext&,
-                                         const StreamInfo::StreamInfo& stream_info) const {
+TraceSampledFormatter::format(const Context&,
+                              const StreamInfo::StreamInfo& stream_info) const {
   return isTraced(stream_info) ? "true" : "false";
 }
 
 Protobuf::Value
-TraceSampledFormatter::formatValueWithContext(const HttpFormatterContext&,
-                                              const StreamInfo::StreamInfo& stream_info) const {
+TraceSampledFormatter::formatValue(const Context&,
+                                   const StreamInfo::StreamInfo& stream_info) const {
   return ValueUtil::stringValue(isTraced(stream_info) ? "true" : "false");
 }
 

--- a/source/common/formatter/http_specific_formatter.h
+++ b/source/common/formatter/http_specific_formatter.h
@@ -160,11 +160,10 @@ public:
  */
 class TraceSampledFormatter : public FormatterProvider {
 public:
-  absl::optional<std::string>
-  formatWithContext(const HttpFormatterContext& context,
-                    const StreamInfo::StreamInfo& stream_info) const override;
-  Protobuf::Value formatValueWithContext(const HttpFormatterContext& context,
-                                         const StreamInfo::StreamInfo& stream_info) const override;
+  absl::optional<std::string> format(const Context& context,
+                                     const StreamInfo::StreamInfo& stream_info) const override;
+  Protobuf::Value formatValue(const Context& context,
+                              const StreamInfo::StreamInfo& stream_info) const override;
 };
 
 class GrpcStatusFormatter : public FormatterProvider, HeaderFormatter {

--- a/source/common/formatter/http_specific_formatter.h
+++ b/source/common/formatter/http_specific_formatter.h
@@ -153,6 +153,20 @@ public:
                               const StreamInfo::StreamInfo& stream_info) const override;
 };
 
+/**
+ * FormatterProvider for trace sampled status.
+ * Uses Envoy's internal tracing decision (stream_info.traceReason()).
+ * Works at trace origin (e.g., Istio Ingress Gateway) where no incoming traceparent header exists.
+ */
+class TraceSampledFormatter : public FormatterProvider {
+public:
+  absl::optional<std::string>
+  formatWithContext(const HttpFormatterContext& context,
+                    const StreamInfo::StreamInfo& stream_info) const override;
+  Protobuf::Value formatValueWithContext(const HttpFormatterContext& context,
+                                         const StreamInfo::StreamInfo& stream_info) const override;
+};
+
 class GrpcStatusFormatter : public FormatterProvider, HeaderFormatter {
 public:
   enum Format {

--- a/source/common/quic/BUILD
+++ b/source/common/quic/BUILD
@@ -566,6 +566,7 @@ envoy_cc_library(
         "//envoy/server:transport_socket_config_interface",
         "//envoy/ssl:context_config_interface",
         "//source/common/common:assert_lib",
+        "//source/common/network:raw_buffer_socket_lib",
         "//source/common/network:transport_socket_options_lib",
         "//source/common/tls:server_context_config_lib",
         "//source/common/tls:server_context_lib",

--- a/source/common/quic/envoy_quic_proof_source.cc
+++ b/source/common/quic/envoy_quic_proof_source.cc
@@ -2,11 +2,16 @@
 
 #include <openssl/bio.h>
 
+#include <cstdlib>
+#include <fstream>
+
 #include "envoy/ssl/tls_certificate_config.h"
 
 #include "source/common/quic/envoy_quic_utils.h"
 #include "source/common/quic/quic_io_handle_wrapper.h"
 #include "source/common/stream_info/stream_info_impl.h"
+#include "source/common/tls/context_config_impl.h"
+#include "source/common/network/utility.h"
 
 #include "openssl/bytestring.h"
 #include "quiche/quic/core/crypto/certificate_view.h"
@@ -27,7 +32,7 @@ EnvoyQuicProofSource::GetCertChain(const quic::QuicSocketAddress& server_address
     return nullptr;
   }
 
-  return getTlsCertAndFilterChain(*res, hostname, cert_matched_sni).cert_;
+  return getTlsCertAndFilterChain(*res, hostname, cert_matched_sni, server_address, client_address).cert_;
 }
 
 void EnvoyQuicProofSource::signPayload(
@@ -42,7 +47,7 @@ void EnvoyQuicProofSource::signPayload(
   }
 
   CertWithFilterChain res =
-      getTlsCertAndFilterChain(*data, hostname, nullptr /* cert_matched_sni */);
+      getTlsCertAndFilterChain(*data, hostname, nullptr /* cert_matched_sni */, server_address, client_address);
   if (res.private_key_ == nullptr) {
     ENVOY_LOG(warn, "No matching filter chain found for handshake.");
     callback->Run(false, "", nullptr);
@@ -72,13 +77,26 @@ void EnvoyQuicProofSource::signPayload(
 EnvoyQuicProofSource::CertWithFilterChain
 EnvoyQuicProofSource::getTlsCertAndFilterChain(const TransportSocketFactoryWithFilterChain& data,
                                                const std::string& hostname,
-                                               bool* cert_matched_sni) {
+                                               bool* cert_matched_sni,
+                                               const quic::QuicSocketAddress& server_address,
+                                               const quic::QuicSocketAddress& client_address) {
   auto [cert, key] =
       data.transport_socket_factory_.getTlsCertificateAndKey(hostname, cert_matched_sni);
   if (cert == nullptr || key == nullptr) {
     ENVOY_LOG(warn, "No certificate is configured in transport socket config.");
     return {};
   }
+
+  // Cache the keylog configuration and connection info for this filter chain
+  try {
+    const auto& context_config = data.transport_socket_factory_.getContextConfig();
+    storeKeylogInfo(data.filter_chain_, 
+                   std::shared_ptr<const Ssl::ContextConfig>(&context_config, [](const Ssl::ContextConfig*){}),
+                   server_address, client_address);
+  } catch (const std::exception& e) {
+    ENVOY_LOG(debug, "Failed to cache keylog info for filter chain: {}", e.what());
+  }
+
   return {std::move(cert), std::move(key), data.filter_chain_};
 }
 
@@ -113,7 +131,162 @@ void EnvoyQuicProofSource::updateFilterChainManager(
   filter_chain_manager_ = &filter_chain_manager;
 }
 
-void EnvoyQuicProofSource::OnNewSslCtx(SSL_CTX* ssl_ctx) { registerCertCompression(ssl_ctx); }
+void EnvoyQuicProofSource::OnNewSslCtx(SSL_CTX* ssl_ctx) {
+  registerCertCompression(ssl_ctx);
+
+  // Try to set up keylog callback for QUIC SSL contexts
+  setupQuicKeylogCallback(ssl_ctx);
+}
+
+void EnvoyQuicProofSource::setupQuicKeylogCallback(SSL_CTX* ssl_ctx) {
+  // Store reference to this proof source in SSL_CTX for use in keylog callback
+  SSL_CTX_set_app_data(ssl_ctx, this);
+
+  // Set up the keylog callback - the actual keylog configuration will be
+  // determined per-connection in the callback based on the filter chain
+  SSL_CTX_set_keylog_callback(ssl_ctx, quicKeylogCallback);
+}
+
+// Helper function to convert Envoy address to QUICHE address
+quic::QuicSocketAddress envoyAddressToQuicAddress(const Network::Address::Instance& envoy_addr) {
+  if (envoy_addr.type() == Network::Address::Type::Ip) {
+    const auto& ip_addr = *envoy_addr.ip();
+    quiche::QuicheIpAddress quiche_addr;
+    if (quiche_addr.FromString(ip_addr.addressAsString())) {
+      return quic::QuicSocketAddress(quic::QuicIpAddress(quiche_addr), ip_addr.port());
+    }
+  }
+  // Return any address for non-IP addresses
+  return quic::QuicSocketAddress();
+}
+
+// Static keylog callback for QUIC SSL contexts
+void EnvoyQuicProofSource::quicKeylogCallback(const SSL* ssl, const char* line) {
+  ASSERT(ssl != nullptr);
+
+  // Get the proof source instance from SSL_CTX
+  auto* proof_source =
+      static_cast<EnvoyQuicProofSource*>(SSL_CTX_get_app_data(SSL_get_SSL_CTX(ssl)));
+  ASSERT(proof_source != nullptr);
+
+  ENVOY_LOG(debug, "QUIC keylog callback invoked for line: {}", line);
+
+  // Try to find keylog configuration from cached filter chain information
+  // We iterate through all cached filter chains to find one with keylog configuration
+  bool keylog_written = false;
+  {
+    absl::MutexLock lock(&proof_source->keylog_cache_mutex_);
+    for (const auto& entry : proof_source->keylog_config_cache_) {
+      const auto& keylog_info = entry.second;
+      if (keylog_info.config) {
+        try {
+          // Convert QUIC addresses back to Envoy addresses for the bridge
+          std::string server_addr_str = absl::StrCat(
+              keylog_info.server_address.host().ToString(), ":", 
+              keylog_info.server_address.port());
+          std::string client_addr_str = absl::StrCat(
+              keylog_info.client_address.host().ToString(), ":", 
+              keylog_info.client_address.port());
+          
+          Network::Address::InstanceConstSharedPtr local_addr = 
+              Network::Utility::parseInternetAddressAndPortNoThrow(server_addr_str);
+          Network::Address::InstanceConstSharedPtr remote_addr = 
+              Network::Utility::parseInternetAddressAndPortNoThrow(client_addr_str);
+
+          if (local_addr && remote_addr) {
+            QuicKeylogBridge::writeKeylog(*keylog_info.config, *local_addr, *remote_addr, line);
+            keylog_written = true;
+            ENVOY_LOG(debug, "QUIC keylog written using cached configuration");
+            break; // Successfully handled by built-in system
+          }
+        } catch (const std::exception& e) {
+          ENVOY_LOG(debug, "Failed to write keylog using cached config: {}", e.what());
+        }
+      }
+    }
+  }
+
+  if (keylog_written) {
+    return;
+  }
+
+  // Fallback: Use environment variable for backward compatibility
+  const char* keylog_path = std::getenv("SSLKEYLOGFILE");
+  if (keylog_path != nullptr) {
+    std::ofstream keylog_file(keylog_path, std::ios::app);
+    if (keylog_file.is_open()) {
+      keylog_file << line << "\n";
+      keylog_file.close();
+      ENVOY_LOG(debug, "QUIC keylog written to {}: {}", keylog_path, line);
+    }
+  }
+}
+
+void EnvoyQuicProofSource::QuicKeylogBridge::writeKeylog(
+    const Ssl::ContextConfig& config, 
+    const Network::Address::Instance& local_addr,
+    const Network::Address::Instance& remote_addr, 
+    const char* line) {
+  
+  const std::string& keylog_path = config.tlsKeyLogPath();
+  if (keylog_path.empty()) {
+    return;
+  }
+
+  // Check address filtering
+  const auto& local_ip_list = config.tlsKeyLogLocal();
+  const auto& remote_ip_list = config.tlsKeyLogRemote();
+  
+  bool local_match = (local_ip_list.getIpListSize() == 0 || local_ip_list.contains(local_addr));
+  bool remote_match = (remote_ip_list.getIpListSize() == 0 || remote_ip_list.contains(remote_addr));
+  
+  if (!local_match || !remote_match) {
+    ENVOY_LOG(debug, "QUIC keylog filtered out by address match (local={}, remote={})", 
+             local_match, remote_match);
+    return;
+  }
+
+  // Use access log manager to write keylog
+  try {
+    auto& access_log_manager = config.accessLogManager();
+    auto file_or_error = access_log_manager.createAccessLog(
+        Filesystem::FilePathAndType{Filesystem::DestinationType::File, keylog_path});
+    
+    if (file_or_error.ok()) {
+      auto keylog_file = file_or_error.value();
+      keylog_file->write(absl::StrCat(line, "\n"));
+      ENVOY_LOG(debug, "QUIC keylog written via bridge to {}: {}", keylog_path, line);
+    } else {
+      ENVOY_LOG(warn, "Failed to create keylog file {}: {}", keylog_path, 
+               file_or_error.status().message());
+    }
+  } catch (const std::exception& e) {
+    ENVOY_LOG(warn, "Failed to write QUIC keylog: {}", e.what());
+  }
+}
+
+// Get SSL socket index for storing transport socket callbacks
+int EnvoyQuicProofSource::sslSocketIndex() {
+  static int ssl_socket_index = SSL_get_ex_new_index(0, nullptr, nullptr, nullptr, nullptr);
+  return ssl_socket_index;
+}
+
+void EnvoyQuicProofSource::storeKeylogInfo(const Network::FilterChain& filter_chain, 
+                                          std::shared_ptr<const Ssl::ContextConfig> config,
+                                          const quic::QuicSocketAddress& server_address,
+                                          const quic::QuicSocketAddress& client_address) const {
+  absl::MutexLock lock(&keylog_cache_mutex_);
+  keylog_config_cache_[&filter_chain] = KeylogInfo{std::move(config), server_address, client_address};
+}
+
+absl::optional<EnvoyQuicProofSource::KeylogInfo> EnvoyQuicProofSource::getKeylogInfo(const Network::FilterChain& filter_chain) const {
+  absl::MutexLock lock(&keylog_cache_mutex_);
+  auto it = keylog_config_cache_.find(&filter_chain);
+  if (it != keylog_config_cache_.end()) {
+    return it->second;
+  }
+  return absl::nullopt;
+}
 
 } // namespace Quic
 } // namespace Envoy

--- a/source/common/quic/envoy_quic_proof_source.h
+++ b/source/common/quic/envoy_quic_proof_source.h
@@ -1,8 +1,17 @@
 #pragma once
 
+#include <unordered_map>
+
+#include "envoy/ssl/context_config.h"
+
+#include "source/common/common/thread.h"
 #include "source/common/quic/envoy_quic_proof_source_base.h"
 #include "source/common/quic/quic_server_transport_socket_factory.h"
 #include "source/server/listener_stats.h"
+
+#include "absl/synchronization/mutex.h"
+#include "absl/types/optional.h"
+#include "quiche/quic/platform/api/quic_socket_address.h"
 
 namespace Envoy {
 namespace Quic {
@@ -10,6 +19,12 @@ namespace Quic {
 // A ProofSource implementation which supplies a proof instance with certs from filter chain.
 class EnvoyQuicProofSource : public EnvoyQuicProofSourceBase {
 public:
+  // Cache for keylog configurations by filter chain
+  struct KeylogInfo {
+    std::shared_ptr<const Ssl::ContextConfig> config;
+    quic::QuicSocketAddress server_address;
+    quic::QuicSocketAddress client_address;
+  };
   EnvoyQuicProofSource(Network::Socket& listen_socket,
                        Network::FilterChainManager& filter_chain_manager,
                        Server::ListenerStats& listener_stats, TimeSource& time_source)
@@ -26,6 +41,15 @@ public:
                bool* cert_matched_sni) override;
 
   void updateFilterChainManager(Network::FilterChainManager& filter_chain_manager);
+
+  // Bridge interface for QUIC-TLS keylog integration
+  class QuicKeylogBridge {
+  public:
+    static void writeKeylog(const Ssl::ContextConfig& config, 
+                           const Network::Address::Instance& local_addr,
+                           const Network::Address::Instance& remote_addr, 
+                           const char* line);
+  };
 
 protected:
   // quic::ProofSource
@@ -47,17 +71,39 @@ private:
   };
 
   CertWithFilterChain getTlsCertAndFilterChain(const TransportSocketFactoryWithFilterChain& data,
-                                               const std::string& hostname, bool* cert_matched_sni);
+                                               const std::string& hostname, bool* cert_matched_sni,
+                                               const quic::QuicSocketAddress& server_address,
+                                               const quic::QuicSocketAddress& client_address);
 
   absl::optional<TransportSocketFactoryWithFilterChain>
   getTransportSocketAndFilterChain(const quic::QuicSocketAddress& server_address,
                                    const quic::QuicSocketAddress& client_address,
                                    const std::string& hostname);
 
+  void setupQuicKeylogCallback(SSL_CTX* ssl_ctx);
+
+  // Static callback function for QUIC keylog
+  static void quicKeylogCallback(const SSL* ssl, const char* line);
+
+  // Get SSL socket index for storing transport socket callbacks
+  static int sslSocketIndex();
+
+  // Store keylog configuration and connection info for a filter chain
+  void storeKeylogInfo(const Network::FilterChain& filter_chain, 
+                      std::shared_ptr<const Ssl::ContextConfig> config,
+                      const quic::QuicSocketAddress& server_address,
+                      const quic::QuicSocketAddress& client_address) const;
+  
+  // Get cached keylog information for a filter chain
+  absl::optional<KeylogInfo> getKeylogInfo(const Network::FilterChain& filter_chain) const;
+
   Network::Socket& listen_socket_;
   Network::FilterChainManager* filter_chain_manager_{nullptr};
   Server::ListenerStats& listener_stats_;
   TimeSource& time_source_;
+
+  mutable absl::Mutex keylog_cache_mutex_;
+  mutable std::unordered_map<const Network::FilterChain*, KeylogInfo> keylog_config_cache_ ABSL_GUARDED_BY(keylog_cache_mutex_);
 };
 
 } // namespace Quic

--- a/source/common/quic/quic_server_transport_socket_factory.h
+++ b/source/common/quic/quic_server_transport_socket_factory.h
@@ -7,6 +7,7 @@
 #include "envoy/ssl/handshaker.h"
 
 #include "source/common/common/assert.h"
+#include "source/common/network/raw_buffer_socket.h"
 #include "source/common/network/transport_socket_options_impl.h"
 #include "source/common/quic/quic_transport_socket_factory.h"
 #include "source/common/tls/server_ssl_socket.h"
@@ -25,8 +26,12 @@ public:
   ~QuicServerTransportSocketFactory() override;
 
   // Network::DownstreamTransportSocketFactory
+  // QUIC uses a different transport socket mechanism, but some code paths may call this
+  // Return a raw buffer socket as a safe fallback
   Network::TransportSocketPtr createDownstreamTransportSocket() const override {
-    PANIC("not implemented");
+    ENVOY_LOG(warn, "createDownstreamTransportSocket called on QUIC transport socket factory. "
+                    "This should not happen in normal QUIC operation.");
+    return std::make_unique<Network::RawBufferSocket>();
   }
   bool implementsSecureTransport() const override { return true; }
 
@@ -37,6 +42,9 @@ public:
   getTlsCertificateAndKey(absl::string_view sni, bool* cert_matched_sni) const;
 
   bool earlyDataEnabled() const { return enable_early_data_; }
+
+  // Access the TLS context configuration (for keylog integration)
+  const Ssl::ServerContextConfig& getContextConfig() const { return *config_; }
 
 protected:
   QuicServerTransportSocketFactory(bool enable_early_data, Stats::Scope& store,

--- a/source/extensions/clusters/redis/redis_cluster.cc
+++ b/source/extensions/clusters/redis/redis_cluster.cc
@@ -100,21 +100,39 @@ RedisCluster::RedisCluster(
   }
 
   // Register the cluster callback using weak_ptr to avoid use-after-free
+  // Also capture a pointer to is_destroying_ to check destruction state
   std::weak_ptr<RedisDiscoverySession> weak_session = redis_discovery_session_;
+  std::atomic<bool>* is_destroying_ptr = &is_destroying_;
   registration_handle_ = refresh_manager_->registerCluster(
       cluster_name_, redirect_refresh_interval_, redirect_refresh_threshold_,
-      failure_refresh_threshold_, host_degraded_refresh_threshold_, [weak_session]() {
+      failure_refresh_threshold_, host_degraded_refresh_threshold_,
+      [weak_session, is_destroying_ptr]() {
+        // Check if cluster is being destroyed first
+        if (is_destroying_ptr->load(std::memory_order_acquire)) {
+          return;
+        }
         // Try to lock the weak pointer to ensure the session is still alive
         auto session = weak_session.lock();
         if (session && session->resolve_timer_) {
           session->resolve_timer_->enableTimer(std::chrono::milliseconds(0));
         }
       });
+
+  // Initialize the session after construction is complete so it can use shared_from_this()
+  redis_discovery_session_->initialize();
 }
 
 RedisCluster::~RedisCluster() {
   // Set flag to prevent any callbacks from executing during destruction
-  is_destroying_.store(true);
+  // Use memory_order_release to ensure this write is visible to callbacks
+  is_destroying_.store(true, std::memory_order_release);
+
+  // CRITICAL: Set the session's parent_destroyed_ flag BEFORE resetting the session.
+  // This allows callbacks with shared_from_this() to safely check if parent is destroyed
+  // without accessing the parent object itself (which may be destroyed).
+  if (redis_discovery_session_) {
+    redis_discovery_session_->parent_destroyed_.store(true, std::memory_order_release);
+  }
 
   // Reset redis_discovery_session_ before other members are destroyed
   // to ensure any pending callbacks from refresh_manager_ don't access it.
@@ -124,6 +142,11 @@ RedisCluster::~RedisCluster() {
   // Also clear DNS discovery targets to prevent their callbacks from
   // accessing the destroyed cluster.
   dns_discovery_resolve_targets_.clear();
+  
+  // Reset the registration handle LAST to ensure no new callbacks are scheduled
+  // while we're cleaning up. Any callbacks already scheduled will check is_destroying_
+  // and return early.
+  registration_handle_.reset();
 }
 
 void RedisCluster::startPreInit() {
@@ -254,6 +277,10 @@ RedisCluster::DnsDiscoveryResolveTarget::~DnsDiscoveryResolveTarget() {
 void RedisCluster::DnsDiscoveryResolveTarget::startResolveDns() {
   ENVOY_LOG(trace, "starting async DNS resolution for {}", dns_address_);
 
+  if (parent_.is_destroying_.load(std::memory_order_acquire) || !parent_.dns_resolver_) {
+    return;
+  }
+
   active_query_ = parent_.dns_resolver_->resolve(
       dns_address_, parent_.dns_lookup_family_,
       [this](Network::DnsResolver::ResolutionStatus status, absl::string_view,
@@ -261,26 +288,34 @@ void RedisCluster::DnsDiscoveryResolveTarget::startResolveDns() {
         active_query_ = nullptr;
         ENVOY_LOG(trace, "async DNS resolution complete for {}", dns_address_);
         if (status == Network::DnsResolver::ResolutionStatus::Failure || response.empty()) {
-          if (status == Network::DnsResolver::ResolutionStatus::Failure) {
-            parent_.info_->configUpdateStats().update_failure_.inc();
-          } else {
-            parent_.info_->configUpdateStats().update_empty_.inc();
+          auto info = parent_.info_;
+          if (info) {
+            if (status == Network::DnsResolver::ResolutionStatus::Failure) {
+              info->configUpdateStats().update_failure_.inc();
+            } else {
+              info->configUpdateStats().update_empty_.inc();
+            }
           }
 
           if (!resolve_timer_) {
-            resolve_timer_ = parent_.dispatcher_.createTimer([this]() -> void {
-              // Check if the parent cluster is being destroyed
-              if (parent_.is_destroying_.load()) {
-                return;
-              }
-              startResolveDns();
-            });
+            resolve_timer_ =
+                parent_.dispatcher_.createTimer([this]() -> void {
+                  // Check if the parent cluster is being destroyed
+                  if (parent_.is_destroying_.load()) {
+                    return;
+                  }
+                  startResolveDns();
+                });
           }
           // if the initial dns resolved to empty, we'll skip the redis discovery phase and
           // treat it as an empty cluster.
           parent_.onPreInitComplete();
           resolve_timer_->enableTimer(parent_.cluster_refresh_rate_);
         } else {
+          // Check if the parent cluster is being destroyed
+          if (parent_.is_destroying_.load(std::memory_order_acquire)) {
+            return;
+          }
           // Once the DNS resolve the initial set of addresses, call startResolveRedis on
           // the RedisDiscoverySession. The RedisDiscoverySession will using the "cluster
           // slots" command for service discovery and slot allocation. All subsequent
@@ -297,17 +332,22 @@ RedisCluster::RedisDiscoverySession::RedisDiscoverySession(
     Envoy::Extensions::Clusters::Redis::RedisCluster& parent,
     NetworkFilters::Common::Redis::Client::ClientFactory& client_factory)
     : parent_(parent), dispatcher_(parent.dispatcher_),
-      resolve_timer_(parent.dispatcher_.createTimer([this]() -> void {
-        // Check if the parent cluster is being destroyed
-        if (parent_.is_destroying_.load()) {
-          return;
-        }
-        startResolveRedis();
-      })),
+      resolve_timer_(nullptr),
       client_factory_(client_factory), buffer_timeout_(0),
       redis_command_stats_(
           NetworkFilters::Common::Redis::RedisCommandStats::createRedisCommandStats(
               parent_.info()->statsScope().symbolTable())) {}
+
+void RedisCluster::RedisDiscoverySession::initialize() {
+  // Create timer with shared_from_this() to keep session alive during callbacks
+  auto self = shared_from_this();
+  resolve_timer_ = dispatcher_.createTimer([self]() -> void {
+    if (!self->isParentAlive()) {
+      return;
+    }
+    self->startResolveRedis();
+  });
+}
 
 // Convert the cluster slot IP/Port response to an address, return null if the response
 // does not match the expected type.
@@ -336,6 +376,10 @@ RedisCluster::RedisDiscoverySession::~RedisDiscoverySession() {
 void RedisCluster::RedisDiscoveryClient::onEvent(Network::ConnectionEvent event) {
   if (event == Network::ConnectionEvent::RemoteClose ||
       event == Network::ConnectionEvent::LocalClose) {
+    // Check if the parent cluster is being destroyed
+    if (parent_.parent_.is_destroying_.load(std::memory_order_acquire)) {
+      return;
+    }
     auto client_to_delete = parent_.client_map_.find(host_);
     ASSERT(client_to_delete != parent_.client_map_.end());
     parent_.dispatcher_.deferredDelete(std::move(client_to_delete->second->client_));
@@ -356,11 +400,17 @@ void RedisCluster::RedisDiscoverySession::registerDiscoveryAddress(
 }
 
 void RedisCluster::RedisDiscoverySession::startResolveRedis() {
-  parent_.info_->configUpdateStats().update_attempt_.inc();
+  // Use helper to safely get parent info (returns nullptr if parent is being destroyed)
+  auto info = parentInfo();
+  if (!info) {
+    return;
+  }
+  
+  info->configUpdateStats().update_attempt_.inc();
   // If a resolution is currently in progress, skip it.
   if (current_request_) {
     ENVOY_LOG(debug, "redis cluster slot request is already in progress for '{}'",
-              parent_.info_->name());
+              info ? info->name() : "unknown");
     return;
   }
 
@@ -382,23 +432,33 @@ void RedisCluster::RedisDiscoverySession::startResolveRedis() {
   if (!client) {
     client = std::make_unique<RedisDiscoveryClient>(*this);
     client->host_ = current_host_address_;
+    // Get parent info again in case parent was destroyed between checks
+    auto parent_info = parentInfo();
+    if (!parent_info) {
+      return;
+    }
     // absl::nullopt here disables AWS IAM authentication in redis client which is not supported by
     // redis cluster implementation
     client->client_ = client_factory_.create(
-        host, dispatcher_, shared_from_this(), redis_command_stats_, parent_.info()->statsScope(),
+        host, dispatcher_, shared_from_this(), redis_command_stats_, parent_info->statsScope(),
         parent_.auth_username_, parent_.auth_password_, false, absl::nullopt, absl::nullopt);
     client->client_->addConnectionCallbacks(*client);
   }
-  ENVOY_LOG(debug, "executing redis cluster slot request for '{}'", parent_.info_->name());
+  ENVOY_LOG(debug, "executing redis cluster slot request for '{}'", 
+            info ? info->name() : "unknown");
   current_request_ = client->client_->makeRequest(ClusterSlotsRequest::instance_, *this);
 }
 
 void RedisCluster::RedisDiscoverySession::updateDnsStats(
     Network::DnsResolver::ResolutionStatus status, bool empty_response) {
+  auto info = parentInfo();
+  if (!info) {
+    return;
+  }
   if (status == Network::DnsResolver::ResolutionStatus::Failure) {
-    parent_.info_->configUpdateStats().update_failure_.inc();
+    info->configUpdateStats().update_failure_.inc();
   } else if (empty_response) {
-    parent_.info_->configUpdateStats().update_empty_.inc();
+    info->configUpdateStats().update_empty_.inc();
   }
 }
 
@@ -419,6 +479,10 @@ void RedisCluster::RedisDiscoverySession::updateDnsStats(
 void RedisCluster::RedisDiscoverySession::resolveClusterHostnames(
     ClusterSlotsSharedPtr&& slots,
     std::shared_ptr<std::uint64_t> hostname_resolution_required_cnt) {
+  if (!isParentAlive() || !parent_.dns_resolver_) {
+    return;
+  }
+  
   for (uint64_t slot_idx = 0; slot_idx < slots->size(); slot_idx++) {
     auto& slot = (*slots)[slot_idx];
     if (slot.primary() == nullptr) {
@@ -430,6 +494,10 @@ void RedisCluster::RedisDiscoverySession::resolveClusterHostnames(
           [this, slot_idx, slots, hostname_resolution_required_cnt](
               Network::DnsResolver::ResolutionStatus status, absl::string_view,
               std::list<Network::DnsResponse>&& response) -> void {
+            if (!isParentAlive()) {
+              return;
+            }
+            
             auto& slot = (*slots)[slot_idx];
             ENVOY_LOG(
                 debug,
@@ -477,6 +545,10 @@ void RedisCluster::RedisDiscoverySession::resolveClusterHostnames(
 void RedisCluster::RedisDiscoverySession::resolveReplicas(
     ClusterSlotsSharedPtr slots, std::size_t index,
     std::shared_ptr<std::uint64_t> hostname_resolution_required_cnt) {
+  if (!isParentAlive() || !parent_.dns_resolver_) {
+    return;
+  }
+  
   auto& slot = (*slots)[index];
   if (slot.replicas_to_resolve_.empty()) {
     if (*hostname_resolution_required_cnt == 0) {
@@ -493,6 +565,11 @@ void RedisCluster::RedisDiscoverySession::resolveReplicas(
         [this, index, slots, replica_idx, hostname_resolution_required_cnt](
             Network::DnsResolver::ResolutionStatus status, absl::string_view,
             std::list<Network::DnsResponse>&& response) -> void {
+          // Check if the parent cluster is being destroyed before accessing any parent members
+          if (parent_.is_destroying_.load(std::memory_order_acquire)) {
+            return;
+          }
+          
           auto& slot = (*slots)[index];
           auto& replica = slot.replicas_to_resolve_[replica_idx];
           ENVOY_LOG(debug, "async DNS resolution complete for replica address {}", replica.first);
@@ -521,17 +598,28 @@ void RedisCluster::RedisDiscoverySession::resolveReplicas(
 
 void RedisCluster::RedisDiscoverySession::finishClusterHostnameResolution(
     ClusterSlotsSharedPtr slots) {
+  if (!isParentAlive()) {
+    return;
+  }
   if (parent_.enable_zone_discovery_) {
     startZoneDiscovery(std::move(slots));
-  } else {
-    parent_.onClusterSlotUpdate(std::move(slots));
+    return;
+  }
+  parent_.onClusterSlotUpdate(std::move(slots));
+  if (resolve_timer_) {
     resolve_timer_->enableTimer(parent_.cluster_refresh_rate_);
   }
 }
 
 void RedisCluster::RedisDiscoverySession::onResponse(
     NetworkFilters::Common::Redis::RespValuePtr&& value) {
-  ENVOY_LOG(debug, "redis cluster slot request for '{}' succeeded", parent_.info_->name());
+  auto info = parentInfo();
+  if (!info) {
+    current_request_ = nullptr;
+    return;
+  }
+  ENVOY_LOG(debug, "redis cluster slot request for '{}' succeeded", 
+            info ? info->name() : "unknown");
   current_request_ = nullptr;
 
   const uint32_t SlotRangeStart = 0;
@@ -628,8 +716,10 @@ void RedisCluster::RedisDiscoverySession::onResponse(
     // All slots addresses were represented by IP/Port pairs.
     if (parent_.enable_zone_discovery_) {
       startZoneDiscovery(std::move(cluster_slots));
-    } else {
-      parent_.onClusterSlotUpdate(std::move(cluster_slots));
+      return;
+    }
+    parent_.onClusterSlotUpdate(std::move(cluster_slots));
+    if (resolve_timer_) {
       resolve_timer_->enableTimer(parent_.cluster_refresh_rate_);
     }
   }
@@ -661,20 +751,36 @@ bool RedisCluster::RedisDiscoverySession::validateCluster(
 
 void RedisCluster::RedisDiscoverySession::onUnexpectedResponse(
     const NetworkFilters::Common::Redis::RespValuePtr& value) {
+  // Check if the parent cluster is being destroyed before accessing any parent members
+  auto info = parentInfo();
+  if (!info) {
+    return;
+  }
+  
   ENVOY_LOG(warn, "Unexpected response to cluster slot command: {}", value->toString());
-  this->parent_.info_->configUpdateStats().update_failure_.inc();
-  resolve_timer_->enableTimer(parent_.cluster_refresh_rate_);
+  info->configUpdateStats().update_failure_.inc();
+  if (resolve_timer_) {
+    resolve_timer_->enableTimer(parent_.cluster_refresh_rate_);
+  }
 }
 
 void RedisCluster::RedisDiscoverySession::onFailure() {
-  ENVOY_LOG(debug, "redis cluster slot request for '{}' failed", parent_.info_->name());
   current_request_ = nullptr;
+  
+  auto info = parentInfo();
+  if (!info) {
+    return;
+  }
+  
+  ENVOY_LOG(debug, "redis cluster slot request for '{}' failed", info->name());
   if (!current_host_address_.empty()) {
     auto client_to_delete = client_map_.find(current_host_address_);
     client_to_delete->second->client_->close();
   }
-  parent_.info()->configUpdateStats().update_failure_.inc();
-  resolve_timer_->enableTimer(parent_.cluster_refresh_rate_);
+  info->configUpdateStats().update_failure_.inc();
+  if (resolve_timer_) {
+    resolve_timer_->enableTimer(parent_.cluster_refresh_rate_);
+  }
 }
 
 // ZoneDiscoveryCallback implementation

--- a/source/extensions/clusters/redis/redis_cluster.h
+++ b/source/extensions/clusters/redis/redis_cluster.h
@@ -267,6 +267,9 @@ private:
 
     ~RedisDiscoverySession() override;
 
+    // Initialize timer - must be called after construction since it uses shared_from_this()
+    void initialize();
+
     void registerDiscoveryAddress(std::list<Network::DnsResponse>&& response, const uint32_t port);
 
     // Start discovery against a random host from existing hosts
@@ -319,6 +322,28 @@ private:
     void finishClusterHostnameResolution(ClusterSlotsSharedPtr slots);
     void updateDnsStats(Network::DnsResolver::ResolutionStatus status, bool empty_response);
 
+  private:
+    friend class RedisCluster;
+    friend struct RedisCluster::DnsDiscoveryResolveTarget;
+    friend struct RedisDiscoveryClient;
+    // Thread-safe check if parent cluster is being destroyed.
+    // Returns true if it's safe to proceed with parent operations.
+    // NOTE: We check our own flag instead of parent_.is_destroying_ because
+    // parent_ is a reference that becomes dangling after parent is destroyed.
+    bool isParentAlive() const {
+      return !parent_destroyed_.load(std::memory_order_acquire);
+    }
+
+    // Thread-safe accessor for parent cluster info.
+    // Returns nullptr if parent is being destroyed or info is not available.
+    // This encapsulates the safety checks needed when accessing parent state from callbacks.
+    Upstream::ClusterInfoConstSharedPtr parentInfo() const {
+      if (!isParentAlive()) {
+        return nullptr;
+      }
+      return parent_.info_;
+    }
+
     RedisCluster& parent_;
     Event::Dispatcher& dispatcher_;
     std::string current_host_address_;
@@ -340,6 +365,11 @@ private:
                         Extensions::NetworkFilters::Common::Redis::Client::PoolRequest*>
         zone_requests_;
     HostZoneMap discovered_zones_; // address -> zone mapping from INFO responses
+
+    // Flag set by parent's destructor to signal that parent is being destroyed.
+    // Callbacks check this flag (owned by session) instead of accessing parent's flag
+    // to avoid use-after-free when parent is destroyed but callbacks are still queued.
+    std::atomic<bool> parent_destroyed_{false};
   };
 
   Upstream::ClusterManager& cluster_manager_;

--- a/source/extensions/clusters/redis/redis_cluster.h
+++ b/source/extensions/clusters/redis/redis_cluster.h
@@ -294,6 +294,8 @@ private:
     std::chrono::milliseconds bufferFlushTimeoutInMs() const override { return buffer_timeout_; }
     uint32_t maxUpstreamUnknownConnections() const override { return 0; }
     bool enableCommandStats() const override { return true; }
+    bool enablePerShardStats() const override { return false; }         // Not needed for discovery
+    bool enablePerShardLatencyStats() const override { return false; }  // Not needed for discovery
     bool connectionRateLimitEnabled() const override { return false; }
     uint32_t connectionRateLimitPerSec() const override { return 0; }
     // For any readPolicy other than Primary, the RedisClientFactory will send a READONLY command

--- a/source/extensions/filters/network/common/redis/client.h
+++ b/source/extensions/filters/network/common/redis/client.h
@@ -194,6 +194,16 @@ public:
   virtual bool enableCommandStats() const PURE;
 
   /**
+   * @return when enabled, per-shard statistics will be recorded for tracking hot shard usage.
+   */
+  virtual bool enablePerShardStats() const PURE;
+
+  /**
+   * @return when enabled, per-shard latency histograms will be recorded.
+   */
+  virtual bool enablePerShardLatencyStats() const PURE;
+
+  /**
    * @return the read policy the proxy should use.
    */
   virtual ReadPolicy readPolicy() const PURE;

--- a/source/extensions/filters/network/common/redis/client_impl.cc
+++ b/source/extensions/filters/network/common/redis/client_impl.cc
@@ -41,7 +41,9 @@ ConfigImpl::ConfigImpl(
                // as the buffer is flushed on each request immediately.
       max_upstream_unknown_connections_(
           PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, max_upstream_unknown_connections, 100)),
-      enable_command_stats_(config.enable_command_stats()) {
+      enable_command_stats_(config.enable_command_stats()),
+      enable_per_shard_stats_(config.enable_per_shard_stats()),
+      enable_per_shard_latency_stats_(config.enable_per_shard_latency_stats()) {
   switch (config.read_policy()) {
     PANIC_ON_PROTO_ENUM_SENTINEL_VALUES;
   case envoy::extensions::filters::network::redis_proxy::v3::RedisProxy::ConnPoolSettings::MASTER:

--- a/source/extensions/filters/network/common/redis/client_impl.h
+++ b/source/extensions/filters/network/common/redis/client_impl.h
@@ -54,6 +54,8 @@ public:
     return max_upstream_unknown_connections_;
   }
   bool enableCommandStats() const override { return enable_command_stats_; }
+  bool enablePerShardStats() const override { return enable_per_shard_stats_; }
+  bool enablePerShardLatencyStats() const override { return enable_per_shard_latency_stats_; }
   ReadPolicy readPolicy() const override { return read_policy_; }
   bool connectionRateLimitEnabled() const override { return connection_rate_limit_enabled_; }
   uint32_t connectionRateLimitPerSec() const override { return connection_rate_limit_per_sec_; }
@@ -66,6 +68,8 @@ private:
   const std::chrono::milliseconds buffer_flush_timeout_;
   const uint32_t max_upstream_unknown_connections_;
   const bool enable_command_stats_;
+  const bool enable_per_shard_stats_;
+  const bool enable_per_shard_latency_stats_;
   ReadPolicy read_policy_;
   bool connection_rate_limit_enabled_;
   uint32_t connection_rate_limit_per_sec_;

--- a/source/extensions/filters/network/common/redis/supported_commands.h
+++ b/source/extensions/filters/network/common/redis/supported_commands.h
@@ -59,7 +59,8 @@ struct SupportedCommands {
    * @return commands which hash on the fourth argument
    */
   static const absl::flat_hash_set<std::string>& evalCommands() {
-    CONSTRUCT_ON_FIRST_USE(absl::flat_hash_set<std::string>, "eval", "evalsha");
+    CONSTRUCT_ON_FIRST_USE(absl::flat_hash_set<std::string>, "eval", "evalsha", "eval_ro",
+                           "evalsha_ro");
   }
 
   /**

--- a/source/extensions/filters/network/common/redis/supported_commands.h
+++ b/source/extensions/filters/network/common/redis/supported_commands.h
@@ -34,8 +34,9 @@ struct SupportedCommands {
         "incrbyfloat", "lindex", "linsert", "llen", "lmove", "lpop", "lpush", "lpushx", "lrange",
         "lrem", "lset", "ltrim", "persist", "pexpire", "pexpireat", "pfadd", "pfcount", "psetex",
         "pttl", "publish", "restore", "rpop", "rpush", "rpushx", "sadd", "scard", "set", "setbit",
-        "setex", "setnx", "setrange", "sismember", "smembers", "spop", "srandmember", "srem",
-        "sscan", "strlen", "ttl", "type", "xack", "xadd", "xautoclaim", "xclaim", "xdel", "xlen",
+        "setex", "setnx", "setrange", "sismember", "smembers", "spop", "spublish", "srandmember", "srem",
+        "sscan", "ssubscribe", "strlen", "subscribe", "sunsubscribe", "ttl", "type", "watch",
+        "xack", "xadd", "xautoclaim", "xclaim", "xdel", "xlen",
         "xpending", "xrange", "xrevrange", "xtrim", "zadd", "zcard", "zcount", "zincrby",
         "zlexcount", "zpopmin", "zpopmax", "zrange", "zrangebylex", "zrangebyscore", "zrank",
         "zrem", "zremrangebylex", "zremrangebyrank", "zremrangebyscore", "zrevrange",
@@ -174,11 +175,11 @@ struct SupportedCommands {
         "hincrbyfloat", "hmset", "hset", "hsetnx", "incr", "incrby", "incrbyfloat", "linsert",
         "lmove", "lpop", "lpush", "lpushx", "lrem", "lset", "ltrim", "mset", "multi", "persist",
         "pexpire", "pexpireat", "pfadd", "psetex", "restore", "rpop", "rpush", "rpushx", "sadd",
-        "set", "setbit", "setex", "setnx", "setrange", "spop", "srem", "zadd", "zincrby", "touch",
-        "zpopmin", "zpopmax", "zrem", "zremrangebylex", "zremrangebyrank", "zremrangebyscore",
-        "unlink", "copy", "rpoplpush", "smove", "sinterstore", "zunionstore", "zinterstore",
-        "pfmerge", "georadius", "georadiusbymember", "rename", "sort", "sdiffstore", "msetnx",
-        "zrangestore", "sunionstore", "geosearchstore", "zdiffstore", "bitop", "renamenx");
+        "set", "setbit", "setex", "setnx", "setrange", "spop", "spublish", "srem", "zadd", "zincrby",
+        "touch", "zpopmin", "zpopmax", "zrem", "zremrangebylex", "zremrangebyrank",
+        "zremrangebyscore", "unlink", "copy", "rpoplpush", "smove", "sinterstore", "zunionstore",
+        "zinterstore", "pfmerge", "georadius", "georadiusbymember", "rename", "sort", "sdiffstore",
+        "msetnx", "zrangestore", "sunionstore", "geosearchstore", "zdiffstore", "bitop", "renamenx");
   }
 
   static bool isReadCommand(const std::string& command) {

--- a/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
@@ -272,6 +272,52 @@ void InstanceImpl::ThreadLocalPool::drainClients() {
   }
 }
 
+RedisShardStatsSharedPtr
+InstanceImpl::ThreadLocalPool::getOrCreateShardStats(const std::string& host_address) {
+  auto it = shard_stats_map_.find(host_address);
+  if (it != shard_stats_map_.end()) {
+    return it->second.stats_;
+  }
+
+  // Create a sanitized stat name from the host address (replace ':' and '.' with '_')
+  std::string stat_name = host_address;
+  std::replace(stat_name.begin(), stat_name.end(), ':', '_');
+  std::replace(stat_name.begin(), stat_name.end(), '.', '_');
+
+  Stats::ScopeSharedPtr shard_scope = stats_scope_->createScope(fmt::format("shard.{}.", stat_name));
+  auto shard_stats = std::make_shared<RedisShardStats>(RedisShardStats{
+      REDIS_SHARD_STATS(POOL_COUNTER(*shard_scope), POOL_GAUGE(*shard_scope))});
+  // Store both scope and stats to keep the scope alive
+  shard_stats_map_[host_address] = ShardStatsEntry{shard_scope, shard_stats};
+  return shard_stats;
+}
+
+Stats::ScopeSharedPtr
+InstanceImpl::ThreadLocalPool::getShardScope(const std::string& host_address) {
+  auto it = shard_stats_map_.find(host_address);
+  if (it != shard_stats_map_.end()) {
+    return it->second.scope_;
+  }
+  return nullptr;
+}
+
+Stats::Histogram*
+InstanceImpl::ThreadLocalPool::getOrCreateShardLatencyHistogram(const std::string& host_address) {
+  auto it = shard_stats_map_.find(host_address);
+  if (it == shard_stats_map_.end()) {
+    // Create shard stats entry first if it doesn't exist
+    getOrCreateShardStats(host_address);
+    it = shard_stats_map_.find(host_address);
+  }
+
+  if (it->second.latency_histogram_ == nullptr) {
+    // Create the histogram if it doesn't exist
+    it->second.latency_histogram_ = &it->second.scope_->histogramFromString(
+        "upstream_rq_time", Stats::Histogram::Unit::Microseconds);
+  }
+  return it->second.latency_histogram_;
+}
+
 InstanceImpl::ThreadLocalActiveClientPtr&
 InstanceImpl::ThreadLocalPool::threadLocalActiveClient(Upstream::HostConstSharedPtr host) {
   TokenBucketPtr& rate_limiter = cx_rate_limiter_map_[host];
@@ -467,7 +513,22 @@ InstanceImpl::ThreadLocalPool::makeRequestToHost(Upstream::HostConstSharedPtr& h
     }
   }
 
-  pending_requests_.emplace_back(*this, std::move(request), callbacks, host);
+  // Get or create per-shard stats for tracking hot shard usage (if enabled)
+  RedisShardStatsSharedPtr shard_stats = nullptr;
+  Stats::ScopeSharedPtr shard_scope = nullptr;
+  Stats::Histogram* latency_histogram = nullptr;
+  if (config_->enablePerShardStats()) {
+    const std::string host_address = host->address()->asString();
+    shard_stats = getOrCreateShardStats(host_address);
+    shard_scope = getShardScope(host_address);
+  }
+  if (config_->enablePerShardLatencyStats()) {
+    const std::string host_address = host->address()->asString();
+    latency_histogram = getOrCreateShardLatencyHistogram(host_address);
+  }
+
+  pending_requests_.emplace_back(*this, std::move(request), callbacks, host, shard_stats,
+                                 shard_scope, latency_histogram);
   PendingRequest& pending_request = pending_requests_.back();
 
   if (!transaction.active_) {
@@ -530,9 +591,30 @@ void InstanceImpl::ThreadLocalActiveClient::onEvent(Network::ConnectionEvent eve
 InstanceImpl::PendingRequest::PendingRequest(InstanceImpl::ThreadLocalPool& parent,
                                              RespVariant&& incoming_request,
                                              PoolCallbacks& pool_callbacks,
-                                             Upstream::HostConstSharedPtr& host)
+                                             Upstream::HostConstSharedPtr& host,
+                                             RedisShardStatsSharedPtr shard_stats,
+                                             Stats::ScopeSharedPtr shard_scope,
+                                             Stats::Histogram* latency_histogram)
     : parent_(parent), incoming_request_(std::move(incoming_request)),
-      pool_callbacks_(pool_callbacks), host_(host) {}
+      pool_callbacks_(pool_callbacks), host_(host), shard_stats_(std::move(shard_stats)),
+      shard_scope_(std::move(shard_scope)), latency_histogram_(latency_histogram),
+      start_time_(parent.dispatcher_.timeSource().monotonicTime()) {
+  // Track per-shard request metrics and command stats
+  if (shard_stats_) {
+    shard_stats_->upstream_rq_total_.inc();
+    shard_stats_->upstream_rq_active_.inc();
+  }
+  // Extract and track command name for per-shard command stats
+  if (shard_scope_ && parent_.config_->enableCommandStats()) {
+    command_ = parent_.redis_command_stats_->getCommandFromRequest(getRequest(incoming_request_));
+    parent_.redis_command_stats_->updateStatsTotal(*shard_scope_, command_);
+    // Create per-shard per-command latency timer when both command stats and per-shard latency are enabled
+    if (parent_.config_->enablePerShardLatencyStats()) {
+      command_latency_timer_ = parent_.redis_command_stats_->createCommandTimer(
+          *shard_scope_, command_, parent_.dispatcher_.timeSource());
+    }
+  }
+}
 
 InstanceImpl::PendingRequest::~PendingRequest() {
   cache_load_handle_.reset();
@@ -540,6 +622,15 @@ InstanceImpl::PendingRequest::~PendingRequest() {
   if (request_handler_) {
     request_handler_->cancel();
     request_handler_ = nullptr;
+    // Update per-shard stats - treat cancellation as failure
+    if (shard_stats_) {
+      shard_stats_->upstream_rq_active_.dec();
+      shard_stats_->upstream_rq_failure_.inc();
+    }
+    // Update per-shard command stats (failure due to cancellation)
+    if (shard_scope_ && parent_.config_->enableCommandStats()) {
+      parent_.redis_command_stats_->updateStats(*shard_scope_, command_, false);
+    }
     // If we have to cancel the request on the client, then we'll treat this as failure for pool
     // callback
     pool_callbacks_.onFailure();
@@ -548,12 +639,52 @@ InstanceImpl::PendingRequest::~PendingRequest() {
 
 void InstanceImpl::PendingRequest::onResponse(Common::Redis::RespValuePtr&& response) {
   request_handler_ = nullptr;
+  // Update per-shard stats
+  if (shard_stats_) {
+    shard_stats_->upstream_rq_active_.dec();
+    shard_stats_->upstream_rq_success_.inc();
+  }
+  // Update per-shard command stats (success)
+  if (shard_scope_ && parent_.config_->enableCommandStats()) {
+    parent_.redis_command_stats_->updateStats(*shard_scope_, command_, true);
+  }
+  // Record per-shard latency histogram
+  if (latency_histogram_ != nullptr) {
+    const auto end_time = parent_.dispatcher_.timeSource().monotonicTime();
+    const auto latency_us = std::chrono::duration_cast<std::chrono::microseconds>(
+        end_time - start_time_).count();
+    latency_histogram_->recordValue(latency_us);
+  }
+  // Complete per-shard per-command latency timer
+  if (command_latency_timer_) {
+    command_latency_timer_->complete();
+  }
   pool_callbacks_.onResponse(std::move(response));
   parent_.onRequestCompleted();
 }
 
 void InstanceImpl::PendingRequest::onFailure() {
   request_handler_ = nullptr;
+  // Update per-shard stats
+  if (shard_stats_) {
+    shard_stats_->upstream_rq_active_.dec();
+    shard_stats_->upstream_rq_failure_.inc();
+  }
+  // Update per-shard command stats (failure)
+  if (shard_scope_ && parent_.config_->enableCommandStats()) {
+    parent_.redis_command_stats_->updateStats(*shard_scope_, command_, false);
+  }
+  // Record per-shard latency histogram (even for failures)
+  if (latency_histogram_ != nullptr) {
+    const auto end_time = parent_.dispatcher_.timeSource().monotonicTime();
+    const auto latency_us = std::chrono::duration_cast<std::chrono::microseconds>(
+        end_time - start_time_).count();
+    latency_histogram_->recordValue(latency_us);
+  }
+  // Complete per-shard per-command latency timer
+  if (command_latency_timer_) {
+    command_latency_timer_->complete();
+  }
   pool_callbacks_.onFailure();
   parent_.refresh_manager_->onFailure(parent_.cluster_name_);
   parent_.onRequestCompleted();
@@ -652,6 +783,26 @@ void InstanceImpl::PendingRequest::doRedirection(Common::Redis::RespValuePtr&& v
 void InstanceImpl::PendingRequest::cancel() {
   request_handler_->cancel();
   request_handler_ = nullptr;
+  // Update per-shard stats - treat cancellation as failure
+  if (shard_stats_) {
+    shard_stats_->upstream_rq_active_.dec();
+    shard_stats_->upstream_rq_failure_.inc();
+  }
+  // Update per-shard command stats (failure due to cancellation)
+  if (shard_scope_ && parent_.config_->enableCommandStats()) {
+    parent_.redis_command_stats_->updateStats(*shard_scope_, command_, false);
+  }
+  // Record per-shard latency histogram (even for cancellations)
+  if (latency_histogram_ != nullptr) {
+    const auto end_time = parent_.dispatcher_.timeSource().monotonicTime();
+    const auto latency_us = std::chrono::duration_cast<std::chrono::microseconds>(
+        end_time - start_time_).count();
+    latency_histogram_->recordValue(latency_us);
+  }
+  // Complete per-shard per-command latency timer
+  if (command_latency_timer_) {
+    command_latency_timer_->complete();
+  }
   parent_.onRequestCompleted();
 }
 

--- a/source/extensions/filters/network/redis_proxy/conn_pool_impl.h
+++ b/source/extensions/filters/network/redis_proxy/conn_pool_impl.h
@@ -7,8 +7,10 @@
 #include <string>
 #include <vector>
 
+#include "envoy/common/time.h"
 #include "envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.pb.h"
 #include "envoy/stats/stats_macros.h"
+#include "envoy/stats/timespan.h"
 #include "envoy/thread_local/thread_local.h"
 #include "envoy/upstream/cluster_manager.h"
 
@@ -47,6 +49,32 @@ namespace ConnPool {
 
 struct RedisClusterStats {
   REDIS_CLUSTER_STATS(GENERATE_COUNTER_STRUCT)
+};
+
+/**
+ * Per-shard statistics for tracking hot shard usage.
+ * These metrics help identify which shards are receiving more traffic.
+ */
+#define REDIS_SHARD_STATS(COUNTER, GAUGE)                                                          \
+  COUNTER(upstream_rq_total)                                                                       \
+  COUNTER(upstream_rq_success)                                                                     \
+  COUNTER(upstream_rq_failure)                                                                     \
+  GAUGE(upstream_rq_active, Accumulate)
+
+struct RedisShardStats {
+  REDIS_SHARD_STATS(GENERATE_COUNTER_STRUCT, GENERATE_GAUGE_STRUCT)
+};
+
+using RedisShardStatsSharedPtr = std::shared_ptr<RedisShardStats>;
+
+/**
+ * Struct to hold per-shard stats and the scope they belong to.
+ * The scope must be kept alive for the stats to remain valid.
+ */
+struct ShardStatsEntry {
+  Stats::ScopeSharedPtr scope_;
+  RedisShardStatsSharedPtr stats_;
+  Stats::Histogram* latency_histogram_{nullptr};  // Per-shard latency histogram (optional)
 };
 
 class DoNothingPoolCallbacks : public PoolCallbacks {
@@ -120,7 +148,9 @@ private:
         public Extensions::Common::DynamicForwardProxy::DnsCache::LoadDnsCacheEntryCallbacks,
         public Logger::Loggable<Logger::Id::redis> {
     PendingRequest(ThreadLocalPool& parent, RespVariant&& incoming_request,
-                   PoolCallbacks& pool_callbacks, Upstream::HostConstSharedPtr& host);
+                   PoolCallbacks& pool_callbacks, Upstream::HostConstSharedPtr& host,
+                   RedisShardStatsSharedPtr shard_stats, Stats::ScopeSharedPtr shard_scope,
+                   Stats::Histogram* latency_histogram);
     ~PendingRequest() override;
 
     // Common::Redis::Client::ClientCallbacks
@@ -149,6 +179,12 @@ private:
     bool ask_redirection_;
     Extensions::Common::DynamicForwardProxy::DnsCache::LoadDnsCacheEntryHandlePtr
         cache_load_handle_;
+    RedisShardStatsSharedPtr shard_stats_;
+    Stats::ScopeSharedPtr shard_scope_;  // Scope for per-shard command stats
+    Stats::StatName command_;            // Command name for per-shard command stats
+    Stats::Histogram* latency_histogram_{nullptr};  // Per-shard latency histogram
+    MonotonicTime start_time_;           // Request start time for latency tracking
+    Stats::TimespanPtr command_latency_timer_;  // Per-shard per-command latency timer
   };
 
   struct ThreadLocalPool : public ThreadLocal::ThreadLocalObject,
@@ -181,6 +217,9 @@ private:
     void onHostsAdded(const std::vector<Upstream::HostSharedPtr>& hosts_added);
     void onHostsRemoved(const std::vector<Upstream::HostSharedPtr>& hosts_removed);
     void drainClients();
+    RedisShardStatsSharedPtr getOrCreateShardStats(const std::string& host_address);
+    Stats::ScopeSharedPtr getShardScope(const std::string& host_address);
+    Stats::Histogram* getOrCreateShardLatencyHistogram(const std::string& host_address);
 
     // Upstream::ClusterUpdateCallbacks
     void onClusterAddOrUpdate(absl::string_view cluster_name,
@@ -225,6 +264,8 @@ private:
         aws_iam_authenticator_;
     absl::optional<envoy::extensions::filters::network::redis_proxy::v3::AwsIam> aws_iam_config_;
     std::string client_zone_; // Zone from node.locality.zone
+    // Per-shard stats map keyed by host address (e.g., "10.0.0.1:6379")
+    absl::node_hash_map<std::string, ShardStatsEntry> shard_stats_map_;
   };
 
   const std::string& localZone() const { return local_zone_; }

--- a/source/extensions/health_checkers/redis/redis.h
+++ b/source/extensions/health_checkers/redis/redis.h
@@ -95,6 +95,8 @@ private:
 
     uint32_t maxUpstreamUnknownConnections() const override { return 0; }
     bool enableCommandStats() const override { return false; }
+    bool enablePerShardStats() const override { return false; }         // Not needed for health checks
+    bool enablePerShardLatencyStats() const override { return false; }  // Not needed for health checks
     bool connectionRateLimitEnabled() const override { return false; }
     uint32_t connectionRateLimitPerSec() const override { return 0; }
 

--- a/source/extensions/request_id/uuid/BUILD
+++ b/source/extensions/request_id/uuid/BUILD
@@ -20,6 +20,7 @@ envoy_cc_extension(
     deps = [
         "//envoy/http:request_id_extension_interface",
         "//envoy/server:request_id_extension_config_interface",
+        "//source/common/common:hex_lib",
         "//source/common/common:random_generator_lib",
         "//source/common/stream_info:stream_id_provider_lib",
         "@envoy_api//envoy/extensions/request_id/uuid/v3:pkg_cc_proto",

--- a/source/extensions/request_id/uuid/config.cc
+++ b/source/extensions/request_id/uuid/config.cc
@@ -1,11 +1,16 @@
 #include "source/extensions/request_id/uuid/config.h"
 
+#include <chrono>
+
 #include "envoy/http/header_map.h"
 #include "envoy/tracing/tracer.h"
 
+#include "source/common/common/hex.h"
 #include "source/common/common/random_generator.h"
 #include "source/common/common/utility.h"
 #include "source/common/stream_info/stream_id_provider_impl.h"
+
+#include "absl/strings/str_cat.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -17,7 +22,7 @@ void UUIDRequestIDExtension::set(Http::RequestHeaderMap& request_headers, bool e
 
   // No request ID then set new one anyway.
   if (request_id_header == nullptr || request_id_header->value().empty()) {
-    request_headers.setRequestId(random_.uuid());
+    request_headers.setRequestId(generateUuidV7());
     return;
   }
 
@@ -32,7 +37,7 @@ void UUIDRequestIDExtension::set(Http::RequestHeaderMap& request_headers, bool e
 
   if (!keep_external_id) {
     // If we are not keeping external request ID, then set new one anyway.
-    request_headers.setRequestId(random_.uuid());
+    request_headers.setRequestId(generateUuidV7());
     return;
   }
 
@@ -64,12 +69,15 @@ UUIDRequestIDExtension::getInteger(const Http::RequestHeaderMap& request_headers
     return absl::nullopt;
   }
   const std::string uuid(request_headers.getRequestIdValue());
-  if (uuid.length() < 8) {
+  // UUID format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx (36 chars)
+  // For UUIDv7: first 8 chars contain timestamp, use last 8 hex chars (rand_b) for randomness.
+  // Position 28-35 contains the last 8 hex digits.
+  if (uuid.length() < 36) {
     return absl::nullopt;
   }
 
   uint64_t value;
-  if (!StringUtil::atoull(uuid.substr(0, 8).c_str(), value, 16)) {
+  if (!StringUtil::atoull(uuid.substr(28, 8).c_str(), value, 16)) {
     return absl::nullopt;
   }
 
@@ -95,6 +103,8 @@ UUIDRequestIDExtension::getTraceReason(const Http::RequestHeaderMap& request_hea
     return Tracing::Reason::Sampling;
   case TRACE_CLIENT:
     return Tracing::Reason::ClientForced;
+  case NO_TRACE_V4: // UUIDv4 freshly generated (version bit '4')
+  case NO_TRACE_V7: // UUIDv7 freshly generated (version bit '7')
   default:
     return Tracing::Reason::NotTraceable;
   }
@@ -122,12 +132,71 @@ void UUIDRequestIDExtension::setTraceReason(Http::RequestHeaderMap& request_head
     uuid[TRACE_BYTE_POSITION] = TRACE_SAMPLED;
     break;
   case Tracing::Reason::NotTraceable:
-    uuid[TRACE_BYTE_POSITION] = NO_TRACE;
+    // Preserve the original version bit ('4' for UUIDv4, '7' for UUIDv7).
+    // Only reset if currently set to a trace reason marker.
+    if (uuid[TRACE_BYTE_POSITION] == TRACE_SAMPLED ||
+        uuid[TRACE_BYTE_POSITION] == TRACE_FORCED ||
+        uuid[TRACE_BYTE_POSITION] == TRACE_CLIENT) {
+      // Default to UUIDv7 version bit when clearing trace reason.
+      uuid[TRACE_BYTE_POSITION] = NO_TRACE_V7;
+    }
+    // If already NO_TRACE_V4 or NO_TRACE_V7, leave unchanged.
     break;
   default:
     break;
   }
   request_headers.setRequestId(uuid);
+}
+
+std::string UUIDRequestIDExtension::generateUuidV7() {
+  // Modified UUIDv7: 상위 4비트를 0xF 마커로 설정하여 trace_id와 구분
+  // request_id: fxxxxxxx-xxxx-7xxx-yxxx-xxxxxxxxxxxx ('f'로 시작)
+  // trace_id:   0xxxxxxx-xxxx-7xxx-yxxx-xxxxxxxxxxxx ('0'으로 시작)
+  //
+  // Bit layout:
+  //   [0-3]    4-bit marker (1111 = 0xF for request_id)
+  //   [4-47]   44-bit Unix timestamp in milliseconds (~557 years until ~2527 AD)
+  //   [48-51]  4-bit version (0111 = 7)
+  //   [52-63]  12-bit rand_a
+  //   [64-65]  2-bit variant (10 = RFC 4122)
+  //   [66-127] 62-bit rand_b
+  //
+  // Result format: fxxxxxxx-xxxx-7xxx-yxxx-xxxxxxxxxxxx
+  // where y is one of [8, 9, a, b] (variant bits).
+
+  const uint64_t timestamp_ms = static_cast<uint64_t>(
+      std::chrono::duration_cast<std::chrono::milliseconds>(
+          time_source_.systemTime().time_since_epoch())
+          .count());
+
+  // 실제 timestamp는 44비트만 사용 (상위 4비트는 마커용)
+  // 44비트로 약 557년 표현 가능 (서기 ~2527년까지)
+  const uint64_t timestamp_44bit = timestamp_ms & 0x0FFFFFFFFFFFULL;
+
+  // 상위 4비트에 0xF 마커 설정 → request_id가 'f'로 시작하게 됨
+  constexpr uint64_t kRequestIdMarker = 0xFULL;
+  const uint64_t marked_timestamp = (kRequestIdMarker << 44) | timestamp_44bit;
+
+  // rand_a: 12 bits of randomness for sub-millisecond ordering
+  const uint64_t rand_a = random_.random() & 0x0FFFULL;
+  // rand_b: 62 bits of randomness (2 bits reserved for variant)
+  const uint64_t rand_b = random_.random() & 0x3FFFFFFFFFFFFFFFULL;
+
+  constexpr uint64_t kVersion7 = 0x7ULL;
+  constexpr uint64_t kVariantRfc4122 = 0x2ULL;
+
+  // Build high 64 bits: marked_timestamp (48) | version (4) | rand_a (12)
+  const uint64_t uuid_high = (marked_timestamp << 16) | (kVersion7 << 12) | rand_a;
+  // Build low 64 bits: variant (2) | rand_b (62)
+  const uint64_t uuid_low = (kVariantRfc4122 << 62) | rand_b;
+
+  // Convert to hex strings (16 chars each, zero-padded)
+  std::string high_hex = Hex::uint64ToHex(uuid_high);
+  std::string low_hex = Hex::uint64ToHex(uuid_low);
+
+  // Format: fxxxxxxx-xxxx-7xxx-yxxx-xxxxxxxxxxxx
+  return absl::StrCat(high_hex.substr(0, 8), "-", high_hex.substr(8, 4), "-",
+                      high_hex.substr(12, 4), "-", low_hex.substr(0, 4), "-", low_hex.substr(4, 12));
 }
 
 REGISTER_FACTORY(UUIDRequestIDExtensionFactory, Server::Configuration::RequestIDExtensionFactory);

--- a/source/extensions/request_id/uuid/config.h
+++ b/source/extensions/request_id/uuid/config.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "envoy/common/time.h"
 #include "envoy/extensions/request_id/uuid/v3/uuid.pb.h"
 #include "envoy/extensions/request_id/uuid/v3/uuid.pb.validate.h"
 #include "envoy/http/request_id_extension.h"
@@ -14,15 +15,16 @@ namespace RequestId {
 class UUIDRequestIDExtension : public Envoy::Http::RequestIDExtension {
 public:
   UUIDRequestIDExtension(const envoy::extensions::request_id::uuid::v3::UuidRequestIdConfig& config,
-                         Random::RandomGenerator& random)
-      : random_(random),
+                         Random::RandomGenerator& random, TimeSource& time_source)
+      : random_(random), time_source_(time_source),
         pack_trace_reason_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, pack_trace_reason, true)),
         use_request_id_for_trace_sampling_(
             PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, use_request_id_for_trace_sampling, true)) {}
 
-  static Envoy::Http::RequestIDExtensionSharedPtr defaultInstance(Random::RandomGenerator& random) {
+  static Envoy::Http::RequestIDExtensionSharedPtr
+  defaultInstance(Random::RandomGenerator& random, TimeSource& time_source) {
     return std::make_shared<UUIDRequestIDExtension>(
-        envoy::extensions::request_id::uuid::v3::UuidRequestIdConfig(), random);
+        envoy::extensions::request_id::uuid::v3::UuidRequestIdConfig(), random, time_source);
   }
 
   bool packTraceReason() { return pack_trace_reason_; }
@@ -42,7 +44,22 @@ public:
   bool useRequestIdForTraceSampling() const override { return use_request_id_for_trace_sampling_; }
 
 private:
+  /**
+   * Generates a 128-bit request ID following UUIDv7 format (RFC 9562).
+   *
+   * UUIDv7 layout (128 bits):
+   *   [0-47]   48-bit Unix timestamp (milliseconds)
+   *   [48-51]  4-bit version (0111 = 7)
+   *   [52-63]  12-bit rand_a
+   *   [64-65]  2-bit variant (10)
+   *   [66-127] 62-bit rand_b
+   *
+   * @return 36-character UUID string with hyphens.
+   */
+  std::string generateUuidV7();
+
   Envoy::Random::RandomGenerator& random_;
+  Envoy::TimeSource& time_source_;
   const bool pack_trace_reason_;
   const bool use_request_id_for_trace_sampling_;
 
@@ -61,8 +78,10 @@ private:
   // one modified because of client trace.
   static const char TRACE_CLIENT = 'b';
 
-  // Initial value for freshly generated uuid4.
-  static const char NO_TRACE = '4';
+  // Initial value for freshly generated UUIDv4.
+  static const char NO_TRACE_V4 = '4';
+  // Initial value for freshly generated UUIDv7.
+  static const char NO_TRACE_V7 = '7';
 };
 
 // Factory for the UUID request ID extension.
@@ -79,7 +98,8 @@ public:
         MessageUtil::downcastAndValidate<
             const envoy::extensions::request_id::uuid::v3::UuidRequestIdConfig&>(
             config, context.messageValidationVisitor()),
-        context.serverFactoryContext().api().randomGenerator());
+        context.serverFactoryContext().api().randomGenerator(),
+        context.serverFactoryContext().api().timeSource());
   }
 };
 

--- a/source/extensions/tracers/opentelemetry/span_context_extractor.h
+++ b/source/extensions/tracers/opentelemetry/span_context_extractor.h
@@ -15,8 +15,8 @@ namespace OpenTelemetry {
 
 class OpenTelemetryConstantValues {
 public:
-  const Tracing::TraceContextHandler TRACE_PARENT{"traceparent"};
-  const Tracing::TraceContextHandler TRACE_STATE{"tracestate"};
+  const Tracing::TraceContextHandler TRACE_PARENT{"x-sendbird-traceparent"};
+  const Tracing::TraceContextHandler TRACE_STATE{"x-sendbird-tracestate"};
 };
 
 using OpenTelemetryConstants = ConstSingleton<OpenTelemetryConstantValues>;

--- a/source/extensions/tracers/opentelemetry/tracer.cc
+++ b/source/extensions/tracers/opentelemetry/tracer.cc
@@ -5,6 +5,7 @@
 
 #include "envoy/config/trace/v3/opentelemetry.pb.h"
 
+#include "source/common/common/assert.h"
 #include "source/common/common/empty_string.h"
 #include "source/common/common/hex.h"
 #include "source/common/tracing/common_values.h"
@@ -279,6 +280,34 @@ void Tracer::sendSpan(::opentelemetry::proto::trace::v1::Span& span) {
   }
 }
 
+std::string Tracer::generateTraceIdV7() {
+  // UUIDv7 bit layout (RFC 9562):
+  //   High 64 bits: [timestamp_ms (48)] [version (4)] [rand_a (12)]
+  //   Low 64 bits:  [variant (2)] [rand_b (62)]
+
+  // Get current Unix timestamp in milliseconds.
+  const uint64_t timestamp_ms = static_cast<uint64_t>(
+      std::chrono::duration_cast<std::chrono::milliseconds>(
+          time_source_.systemTime().time_since_epoch())
+          .count());
+  // Timestamp must fit in 48 bits (valid until year ~10889).
+  ASSERT((timestamp_ms >> 48) == 0);
+
+  // Generate random bits.
+  const uint64_t rand_a = random_.random() & 0x0FFFULL;         // 12 bits
+  const uint64_t rand_b = random_.random() & 0x3FFFFFFFFFFFFFFFULL; // 62 bits
+
+  // Assemble high 64 bits: [timestamp_ms(48)][version=7(4)][rand_a(12)]
+  constexpr uint64_t kVersion7 = 0x7ULL;
+  const uint64_t trace_id_high = (timestamp_ms << 16) | (kVersion7 << 12) | rand_a;
+
+  // Assemble low 64 bits: [variant=2(2)][rand_b(62)]
+  constexpr uint64_t kVariantRfc4122 = 0x2ULL;
+  const uint64_t trace_id_low = (kVariantRfc4122 << 62) | rand_b;
+
+  return absl::StrCat(Hex::uint64ToHex(trace_id_high), Hex::uint64ToHex(trace_id_low));
+}
+
 Tracing::SpanPtr Tracer::startSpan(const std::string& operation_name,
                                    const StreamInfo::StreamInfo& stream_info, SystemTime start_time,
                                    Tracing::Decision tracing_decision,
@@ -292,9 +321,7 @@ Tracing::SpanPtr Tracer::startSpan(const std::string& operation_name,
   // Create an Tracers::OpenTelemetry::Span class that will contain the OTel span.
   auto new_span = std::make_unique<Span>(operation_name, stream_info, start_time, time_source_,
                                          *this, span_kind, use_local_decision);
-  uint64_t trace_id_high = random_.random();
-  uint64_t trace_id = random_.random();
-  new_span->setTraceId(absl::StrCat(Hex::uint64ToHex(trace_id_high), Hex::uint64ToHex(trace_id)));
+  new_span->setTraceId(generateTraceIdV7());
   uint64_t span_id = random_.random();
   new_span->setId(Hex::uint64ToHex(span_id));
   if (sampler_) {

--- a/source/extensions/tracers/opentelemetry/tracer.cc
+++ b/source/extensions/tracers/opentelemetry/tracer.cc
@@ -27,11 +27,11 @@ using opentelemetry::proto::collector::trace::v1::ExportTraceServiceRequest;
 namespace {
 
 const Tracing::TraceContextHandler& traceParentHeader() {
-  CONSTRUCT_ON_FIRST_USE(Tracing::TraceContextHandler, "traceparent");
+  CONSTRUCT_ON_FIRST_USE(Tracing::TraceContextHandler, "x-sendbird-traceparent");
 }
 
 const Tracing::TraceContextHandler& traceStateHeader() {
-  CONSTRUCT_ON_FIRST_USE(Tracing::TraceContextHandler, "tracestate");
+  CONSTRUCT_ON_FIRST_USE(Tracing::TraceContextHandler, "x-sendbird-tracestate");
 }
 
 void callSampler(SamplerSharedPtr sampler, const StreamInfo::StreamInfo& stream_info,

--- a/source/extensions/tracers/opentelemetry/tracer.h
+++ b/source/extensions/tracers/opentelemetry/tracer.h
@@ -65,6 +65,19 @@ private:
    * Removes all spans from the span buffer and sends them to the collector.
    */
   void flushSpans();
+  /**
+   * Generates a 128-bit trace ID following UUIDv7 format (RFC 9562).
+   *
+   * UUIDv7 layout (128 bits):
+   *   [0-47]   48-bit Unix timestamp (milliseconds)
+   *   [48-51]  4-bit version (0111 = 7)
+   *   [52-63]  12-bit rand_a
+   *   [64-65]  2-bit variant (10)
+   *   [66-127] 62-bit rand_b
+   *
+   * @return 32-character hex string (128-bit trace ID).
+   */
+  std::string generateTraceIdV7();
 
   OpenTelemetryTraceExporterPtr exporter_;
   Envoy::TimeSource& time_source_;

--- a/source/server/admin/admin.cc
+++ b/source/server/admin/admin.cc
@@ -111,7 +111,7 @@ AdminImpl::AdminImpl(const std::string& profile_path, Server::Instance& server,
     : server_(server), listener_info_(std::make_shared<ListenerInfoImpl>()),
       factory_context_(server, listener_info_),
       request_id_extension_(Extensions::RequestId::UUIDRequestIDExtension::defaultInstance(
-          server_.api().randomGenerator())),
+          server_.api().randomGenerator(), server_.api().timeSource())),
       profile_path_(profile_path), stats_(Http::ConnectionManagerImpl::generateStats(
                                        "http.admin.", *server_.stats().rootScope())),
       null_overload_manager_(server.threadLocal(), false),

--- a/test/common/formatter/substitution_formatter_test.cc
+++ b/test/common/formatter/substitution_formatter_test.cc
@@ -3588,6 +3588,50 @@ TEST(SubstitutionFormatterTest, SpanIDFormatter) {
   }
 }
 
+TEST(SubstitutionFormatterTest, TraceSampledFormatter) {
+  StreamInfo::MockStreamInfo stream_info;
+  Http::TestRequestHeaderMapImpl request_header{};
+  Http::TestResponseHeaderMapImpl response_header{};
+  Http::TestResponseTrailerMapImpl response_trailer{};
+  std::string body;
+  HttpFormatterContext formatter_context(&request_header, &response_header, &response_trailer,
+                                         body);
+  TraceSampledFormatter formatter{};
+
+  // Test traced=true cases: Sampling, ClientForced, ServiceForced
+  {
+    EXPECT_CALL(stream_info, healthCheck()).WillRepeatedly(Return(false));
+    EXPECT_CALL(stream_info, traceReason()).WillRepeatedly(Return(Tracing::Reason::Sampling));
+    EXPECT_EQ("true", formatter.formatWithContext(formatter_context, stream_info));
+    EXPECT_THAT(formatter.formatValueWithContext(formatter_context, stream_info),
+                ProtoEq(ValueUtil::stringValue("true")));
+  }
+  {
+    EXPECT_CALL(stream_info, healthCheck()).WillOnce(Return(false));
+    EXPECT_CALL(stream_info, traceReason()).WillOnce(Return(Tracing::Reason::ClientForced));
+    EXPECT_EQ("true", formatter.formatWithContext(formatter_context, stream_info));
+  }
+  {
+    EXPECT_CALL(stream_info, healthCheck()).WillOnce(Return(false));
+    EXPECT_CALL(stream_info, traceReason()).WillOnce(Return(Tracing::Reason::ServiceForced));
+    EXPECT_EQ("true", formatter.formatWithContext(formatter_context, stream_info));
+  }
+
+  // Test traced=false cases: NotTraceable, HealthCheck
+  {
+    EXPECT_CALL(stream_info, healthCheck()).WillRepeatedly(Return(false));
+    EXPECT_CALL(stream_info, traceReason()).WillRepeatedly(Return(Tracing::Reason::NotTraceable));
+    EXPECT_EQ("false", formatter.formatWithContext(formatter_context, stream_info));
+    EXPECT_THAT(formatter.formatValueWithContext(formatter_context, stream_info),
+                ProtoEq(ValueUtil::stringValue("false")));
+  }
+  {
+    // HealthCheck requests should return false regardless of traceReason
+    EXPECT_CALL(stream_info, healthCheck()).WillOnce(Return(true));
+    EXPECT_EQ("false", formatter.formatWithContext(formatter_context, stream_info));
+  }
+}
+
 /**
  * Populate a metadata object with the following test data:
  * "com.test":

--- a/test/common/quic/envoy_quic_proof_source_test.cc
+++ b/test/common/quic/envoy_quic_proof_source_test.cc
@@ -1,3 +1,7 @@
+#include <unistd.h>
+
+#include <cstdlib>
+#include <fstream>
 #include <memory>
 #include <string>
 #include <vector>
@@ -13,6 +17,7 @@
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/server/server_factory_context.h"
 #include "test/mocks/ssl/mocks.h"
+#include "test/test_common/network_utility.h"
 #include "test/test_common/test_runtime.h"
 
 #include "gmock/gmock.h"
@@ -346,6 +351,177 @@ TEST_F(EnvoyQuicProofSourceTest, ComputeSignatureFailNoFilterChain) {
   proof_source_.ComputeTlsSignature(
       server_address_, client_address_, hostname_, SSL_SIGN_RSA_PSS_RSAE_SHA256, "payload",
       std::make_unique<TestSignatureCallback>(false, filter_chain_, signature));
+}
+
+// Test keylog functionality
+TEST_F(EnvoyQuicProofSourceTest, TestKeylogFunctionality) {
+  // Test that OnNewSslCtx sets up keylog callback correctly
+  bssl::UniquePtr<SSL_CTX> ssl_ctx(SSL_CTX_new(TLS_method()));
+  ASSERT_NE(ssl_ctx, nullptr);
+
+  // Call OnNewSslCtx which should set up the keylog callback
+  proof_source_.OnNewSslCtx(ssl_ctx.get());
+
+  // Verify that the proof source was stored in SSL_CTX app data
+  void* app_data = SSL_CTX_get_app_data(ssl_ctx.get());
+  EXPECT_EQ(app_data, static_cast<void*>(&proof_source_));
+
+  // Verify that keylog callback was set
+  void (*callback)(const SSL*, const char*) = SSL_CTX_get_keylog_callback(ssl_ctx.get());
+  EXPECT_NE(callback, nullptr);
+}
+
+// Test keylog callback registration
+TEST_F(EnvoyQuicProofSourceTest, TestKeylogCallbackRegistration) {
+  // Create SSL_CTX and setup keylog
+  bssl::UniquePtr<SSL_CTX> ssl_ctx(SSL_CTX_new(TLS_method()));
+  proof_source_.OnNewSslCtx(ssl_ctx.get());
+
+  // Verify that keylog callback is registered
+  void (*callback)(const SSL*, const char*) = SSL_CTX_get_keylog_callback(ssl_ctx.get());
+  EXPECT_NE(callback, nullptr);
+
+  // Verify that app data points to our proof source
+  void* app_data = SSL_CTX_get_app_data(ssl_ctx.get());
+  EXPECT_EQ(app_data, static_cast<void*>(&proof_source_));
+}
+
+// Test keylog file writing with environment variable
+TEST_F(EnvoyQuicProofSourceTest, TestKeylogFileWriting) {
+  // Create a temporary file for keylog output
+  std::string temp_file = "/tmp/test_keylog_" + std::to_string(getpid()) + ".txt";
+
+  // Set SSLKEYLOGFILE environment variable
+  setenv("SSLKEYLOGFILE", temp_file.c_str(), 1);
+
+  // Create SSL_CTX and setup keylog
+  bssl::UniquePtr<SSL_CTX> ssl_ctx(SSL_CTX_new(TLS_method()));
+  proof_source_.OnNewSslCtx(ssl_ctx.get());
+
+  // Create SSL connection
+  bssl::UniquePtr<SSL> ssl(SSL_new(ssl_ctx.get()));
+
+  // Get the keylog callback and call it to test functionality
+  void (*callback)(const SSL*, const char*) = SSL_CTX_get_keylog_callback(ssl_ctx.get());
+  ASSERT_NE(callback, nullptr);
+
+  // Call the callback with test data
+  const char* test_line = "CLIENT_RANDOM 0123456789abcdef test_key_material";
+  callback(ssl.get(), test_line);
+
+  // Verify the keylog was written to file
+  std::ifstream keylog_file(temp_file);
+  ASSERT_TRUE(keylog_file.is_open());
+  std::string line;
+  ASSERT_TRUE(std::getline(keylog_file, line));
+  EXPECT_EQ(line, test_line);
+  keylog_file.close();
+
+  // Clean up
+  unlink(temp_file.c_str());
+  unsetenv("SSLKEYLOGFILE");
+}
+
+// Test keylog callback without environment variable
+TEST_F(EnvoyQuicProofSourceTest, TestKeylogCallbackWithoutEnvironmentVariable) {
+  // Ensure SSLKEYLOGFILE is not set
+  unsetenv("SSLKEYLOGFILE");
+
+  // Create SSL_CTX and setup keylog
+  bssl::UniquePtr<SSL_CTX> ssl_ctx(SSL_CTX_new(TLS_method()));
+  proof_source_.OnNewSslCtx(ssl_ctx.get());
+
+  // Verify that keylog callback is still registered (even without env var)
+  void (*callback)(const SSL*, const char*) = SSL_CTX_get_keylog_callback(ssl_ctx.get());
+  EXPECT_NE(callback, nullptr);
+
+  // Create SSL connection and test that callback doesn't crash without env var
+  bssl::UniquePtr<SSL> ssl(SSL_new(ssl_ctx.get()));
+
+  // Call the callback - it should not crash even without SSLKEYLOGFILE set
+  const char* test_line = "CLIENT_RANDOM 0123456789abcdef test_key_material";
+  EXPECT_NO_THROW(callback(ssl.get(), test_line));
+}
+
+// Test QUIC keylog bridge functionality
+TEST_F(EnvoyQuicProofSourceTest, TestQuicKeylogBridge) {
+  // Create a mock context config with keylog configuration
+  NiceMock<Ssl::MockServerContextConfig> mock_config;
+  NiceMock<AccessLog::MockAccessLogManager> mock_access_log_manager;
+  auto mock_access_log_file = std::make_shared<NiceMock<AccessLog::MockAccessLogFile>>();
+  
+  std::string keylog_path = "/tmp/test_bridge_keylog_" + std::to_string(getpid()) + ".txt";
+  
+  // Setup mock expectations
+  EXPECT_CALL(mock_config, tlsKeyLogPath())
+      .WillRepeatedly(ReturnRef(keylog_path));
+  
+  Network::Address::IpList empty_ip_list;
+  EXPECT_CALL(mock_config, tlsKeyLogLocal())
+      .WillRepeatedly(ReturnRef(empty_ip_list));
+  EXPECT_CALL(mock_config, tlsKeyLogRemote())
+      .WillRepeatedly(ReturnRef(empty_ip_list));
+  
+  EXPECT_CALL(mock_config, accessLogManager())
+      .WillRepeatedly(ReturnRef(mock_access_log_manager));
+  
+  EXPECT_CALL(mock_access_log_manager, createAccessLog(_))
+      .WillOnce(Return(absl::StatusOr<AccessLog::AccessLogFileSharedPtr>(mock_access_log_file)));
+  
+  EXPECT_CALL(*mock_access_log_file, write(_))
+      .Times(1);
+
+  // Create test addresses
+  auto local_addr = Network::Test::getCanonicalLoopbackAddress(Network::Address::IpVersion::v4);
+  auto remote_addr = Network::Test::getCanonicalLoopbackAddress(Network::Address::IpVersion::v4);
+  
+  // Test the bridge functionality
+  const char* test_line = "CLIENT_RANDOM 123456789 ABCDEF";
+  EnvoyQuicProofSource::QuicKeylogBridge::writeKeylog(mock_config, *local_addr, *remote_addr, test_line);
+}
+
+// Test the complete keylog callback flow including SSL context setup
+TEST_F(EnvoyQuicProofSourceTest, TestKeylogCallbackWithSslContext) {
+  // Create an SSL context to test the callback registration
+  bssl::UniquePtr<SSL_CTX> ssl_ctx(SSL_CTX_new(TLS_method()));
+  ASSERT_NE(ssl_ctx, nullptr);
+
+  // Use OnNewSslCtx which calls setupQuicKeylogCallback internally
+  proof_source_.OnNewSslCtx(ssl_ctx.get());
+
+  // Create an SSL connection
+  bssl::UniquePtr<SSL> ssl(SSL_new(ssl_ctx.get()));
+  ASSERT_NE(ssl, nullptr);
+
+  // Verify that the keylog callback is set
+  auto callback = SSL_CTX_get_keylog_callback(ssl_ctx.get());
+  EXPECT_NE(callback, nullptr);
+
+  // Verify that the proof source is stored as app data
+  auto stored_proof_source = SSL_CTX_get_app_data(ssl_ctx.get());
+  EXPECT_EQ(stored_proof_source, &proof_source_);
+
+  // Test calling the callback - it should handle the case where transport socket callbacks are not available
+  const char* test_line = "CLIENT_RANDOM 0123456789abcdef test_key_material";
+  
+  // Set up environment variable for fallback test
+  std::string keylog_path = "/tmp/test_callback_keylog_" + std::to_string(getpid()) + ".txt";
+  setenv("SSLKEYLOGFILE", keylog_path.c_str(), 1);
+  
+  EXPECT_NO_THROW(callback(ssl.get(), test_line));
+
+  // Check that the keylog was written via environment variable fallback
+  std::ifstream keylog_file(keylog_path);
+  EXPECT_TRUE(keylog_file.good());
+  if (keylog_file.good()) {
+    std::string line;
+    std::getline(keylog_file, line);
+    EXPECT_EQ(line, test_line);
+  }
+
+  // Clean up
+  unsetenv("SSLKEYLOGFILE");
+  unlink(keylog_path.c_str());
 }
 
 } // namespace Quic

--- a/test/extensions/clusters/redis/redis_cluster_lb_test.cc
+++ b/test/extensions/clusters/redis/redis_cluster_lb_test.cc
@@ -945,7 +945,8 @@ TEST_F(RedisClusterLoadBalancerTest, LocalZoneAffinityEmptyClientZone) {
   };
   validateAssignment(hosts, expected_assignments, true,
                      NetworkFilters::Common::Redis::Client::ReadPolicy::LocalZoneAffinity, "");
-||||||| parent of 36be96a308 (redis: Support eval_ro, evalsha_ro)
+}
+
 TEST_F(RedisLoadBalancerContextImplTest, ReadOnlyCommand) {
   std::vector<NetworkFilters::Common::Redis::RespValue> eval_ro_foo(4);
   eval_ro_foo[0].type(NetworkFilters::Common::Redis::RespType::BulkString);

--- a/test/extensions/clusters/redis/redis_cluster_lb_test.cc
+++ b/test/extensions/clusters/redis/redis_cluster_lb_test.cc
@@ -945,6 +945,30 @@ TEST_F(RedisClusterLoadBalancerTest, LocalZoneAffinityEmptyClientZone) {
   };
   validateAssignment(hosts, expected_assignments, true,
                      NetworkFilters::Common::Redis::Client::ReadPolicy::LocalZoneAffinity, "");
+||||||| parent of 36be96a308 (redis: Support eval_ro, evalsha_ro)
+TEST_F(RedisLoadBalancerContextImplTest, ReadOnlyCommand) {
+  std::vector<NetworkFilters::Common::Redis::RespValue> eval_ro_foo(4);
+  eval_ro_foo[0].type(NetworkFilters::Common::Redis::RespType::BulkString);
+  eval_ro_foo[0].asString() = "eval_ro";
+  eval_ro_foo[1].type(NetworkFilters::Common::Redis::RespType::BulkString);
+  eval_ro_foo[1].asString() = "return {KEYS[1]}";
+  eval_ro_foo[2].type(NetworkFilters::Common::Redis::RespType::BulkString);
+  eval_ro_foo[2].asString() = "foo";
+  eval_ro_foo[3].type(NetworkFilters::Common::Redis::RespType::BulkString);
+  eval_ro_foo[3].asString() = "0";
+
+  NetworkFilters::Common::Redis::RespValue eval_ro_request;
+  eval_ro_request.type(NetworkFilters::Common::Redis::RespType::Array);
+  eval_ro_request.asArray().swap(eval_ro_foo);
+
+  RedisLoadBalancerContextImpl context1(
+      "foo", true, true, eval_ro_request,
+      NetworkFilters::Common::Redis::Client::ReadPolicy::PreferReplica);
+
+  EXPECT_EQ(absl::optional<uint64_t>(44950), context1.computeHashKey());
+  EXPECT_EQ(true, context1.isReadCommand());
+  EXPECT_EQ(NetworkFilters::Common::Redis::Client::ReadPolicy::PreferReplica,
+            context1.readPolicy());
 }
 
 } // namespace Redis

--- a/test/extensions/filters/network/redis_proxy/command_splitter_impl_test.cc
+++ b/test/extensions/filters/network/redis_proxy/command_splitter_impl_test.cc
@@ -536,6 +536,50 @@ TEST_F(RedisSingleServerRequestTest, EvalShaSuccess) {
             store_.counter(fmt::format("redis.foo.command.{}.success", lower_command)).value());
 };
 
+TEST_F(RedisSingleServerRequestTest, EvalRoSuccess) {
+  InSequence s;
+
+  Common::Redis::RespValuePtr request{new Common::Redis::RespValue()};
+  makeBulkStringArray(*request, {"eval_ro", "return {ARGV[1]}", "1", "key", "arg"});
+  makeRequest("key", std::move(request));
+  EXPECT_NE(nullptr, handle_);
+
+  std::string lower_command = absl::AsciiStrToLower("eval_ro");
+
+  time_system_.setMonotonicTime(std::chrono::milliseconds(10));
+  EXPECT_CALL(store_, deliverHistogramToSinks(
+                          Property(&Stats::Metric::name,
+                                   fmt::format("redis.foo.command.{}.latency", lower_command)),
+                          10));
+  respond();
+
+  EXPECT_EQ(1UL, store_.counter(fmt::format("redis.foo.command.{}.total", lower_command)).value());
+  EXPECT_EQ(1UL,
+            store_.counter(fmt::format("redis.foo.command.{}.success", lower_command)).value());
+};
+
+TEST_F(RedisSingleServerRequestTest, EvalShaRoSuccess) {
+  InSequence s;
+
+  Common::Redis::RespValuePtr request{new Common::Redis::RespValue()};
+  makeBulkStringArray(*request, {"EVALSHA_RO", "return {ARGV[1]}", "1", "keykey", "arg"});
+  makeRequest("keykey", std::move(request));
+  EXPECT_NE(nullptr, handle_);
+
+  std::string lower_command = absl::AsciiStrToLower("evalsha_ro");
+
+  time_system_.setMonotonicTime(std::chrono::milliseconds(10));
+  EXPECT_CALL(store_, deliverHistogramToSinks(
+                          Property(&Stats::Metric::name,
+                                   fmt::format("redis.foo.command.{}.latency", lower_command)),
+                          10));
+  respond();
+
+  EXPECT_EQ(1UL, store_.counter(fmt::format("redis.foo.command.{}.total", lower_command)).value());
+  EXPECT_EQ(1UL,
+            store_.counter(fmt::format("redis.foo.command.{}.success", lower_command)).value());
+};
+
 TEST_F(RedisSingleServerRequestTest, EvalWrongNumberOfArgs) {
   InSequence s;
 

--- a/test/extensions/request_id/uuid/BUILD
+++ b/test/extensions/request_id/uuid/BUILD
@@ -18,5 +18,6 @@ envoy_cc_test(
         "//source/extensions/request_id/uuid:config",
         "//test/mocks/runtime:runtime_mocks",
         "//test/mocks/stream_info:stream_info_mocks",
+        "//test/test_common:simulated_time_system_lib",
     ],
 )

--- a/test/extensions/request_id/uuid/config_test.cc
+++ b/test/extensions/request_id/uuid/config_test.cc
@@ -5,6 +5,7 @@
 
 #include "test/mocks/common.h"
 #include "test/mocks/stream_info/mocks.h"
+#include "test/test_common/simulated_time_system.h"
 #include "test/test_common/utility.h"
 
 #include "gtest/gtest.h"
@@ -16,24 +17,30 @@ namespace Extensions {
 namespace RequestId {
 
 TEST(UUIDRequestIDExtensionTest, SetRequestID) {
-  testing::StrictMock<Random::MockRandomGenerator> random;
+  testing::NiceMock<Random::MockRandomGenerator> random;
+  Event::SimulatedTimeSystem time_system;
   UUIDRequestIDExtension uuid_utils(envoy::extensions::request_id::uuid::v3::UuidRequestIdConfig(),
-                                    random);
+                                    random, time_system);
 
   {
     // edge_request: true, keep_external_id: false.
 
     Http::TestRequestHeaderMapImpl request_headers;
 
-    // Without request ID.
-    EXPECT_CALL(random, uuid()).WillOnce(Return("first-request-id"));
+    // Without request ID. generateUuidV7() calls random.random() twice.
     uuid_utils.set(request_headers, true, false);
-    EXPECT_EQ("first-request-id", request_headers.get_(Http::Headers::get().RequestId));
+    std::string first_request_id = std::string(request_headers.get_(Http::Headers::get().RequestId));
+    EXPECT_EQ(36, first_request_id.length());
+    EXPECT_EQ('f', first_request_id[0]); // UUIDv7 request_id marker
+    EXPECT_EQ('7', first_request_id[14]); // UUIDv7 version
 
     // With request ID. Previous one will be overwritten.
-    EXPECT_CALL(random, uuid()).WillOnce(Return("second-request-id"));
     uuid_utils.set(request_headers, true, false);
-    EXPECT_EQ("second-request-id", request_headers.get_(Http::Headers::get().RequestId));
+    std::string second_request_id =
+        std::string(request_headers.get_(Http::Headers::get().RequestId));
+    EXPECT_EQ(36, second_request_id.length());
+    EXPECT_EQ('f', second_request_id[0]);
+    EXPECT_EQ('7', second_request_id[14]);
   }
 
   {
@@ -41,15 +48,14 @@ TEST(UUIDRequestIDExtensionTest, SetRequestID) {
 
     Http::TestRequestHeaderMapImpl request_headers;
 
-    // Without request ID.
-    EXPECT_CALL(random, uuid()).WillOnce(Return("first-request-id"));
+    // Without request ID. generateUuidV7() calls random.random() twice.
     uuid_utils.set(request_headers, true, true);
-    EXPECT_EQ("first-request-id", request_headers.get_(Http::Headers::get().RequestId));
+    std::string first_request_id = std::string(request_headers.get_(Http::Headers::get().RequestId));
+    EXPECT_EQ(36, first_request_id.length());
 
     // With request ID. Previous one will be kept.
-    EXPECT_CALL(random, uuid()).Times(0);
     uuid_utils.set(request_headers, true, true);
-    EXPECT_EQ("first-request-id", request_headers.get_(Http::Headers::get().RequestId));
+    EXPECT_EQ(first_request_id, request_headers.get_(Http::Headers::get().RequestId));
   }
 
   {
@@ -57,15 +63,14 @@ TEST(UUIDRequestIDExtensionTest, SetRequestID) {
 
     Http::TestRequestHeaderMapImpl request_headers;
 
-    // Without request ID.
-    EXPECT_CALL(random, uuid()).WillOnce(Return("first-request-id"));
+    // Without request ID. generateUuidV7() calls random.random() twice.
     uuid_utils.set(request_headers, false, false);
-    EXPECT_EQ("first-request-id", request_headers.get_(Http::Headers::get().RequestId));
+    std::string first_request_id = std::string(request_headers.get_(Http::Headers::get().RequestId));
+    EXPECT_EQ(36, first_request_id.length());
 
     // With request ID. Previous one will be kept.
-    EXPECT_CALL(random, uuid()).Times(0);
     uuid_utils.set(request_headers, false, false);
-    EXPECT_EQ("first-request-id", request_headers.get_(Http::Headers::get().RequestId));
+    EXPECT_EQ(first_request_id, request_headers.get_(Http::Headers::get().RequestId));
   }
 
   {
@@ -73,32 +78,34 @@ TEST(UUIDRequestIDExtensionTest, SetRequestID) {
 
     Http::TestRequestHeaderMapImpl request_headers;
 
-    // Without request ID.
-    EXPECT_CALL(random, uuid()).WillOnce(Return("first-request-id"));
+    // Without request ID. generateUuidV7() calls random.random() twice.
     uuid_utils.set(request_headers, false, true);
-    EXPECT_EQ("first-request-id", request_headers.get_(Http::Headers::get().RequestId));
+    std::string first_request_id = std::string(request_headers.get_(Http::Headers::get().RequestId));
+    EXPECT_EQ(36, first_request_id.length());
 
     // With request ID. Previous one will be kept.
-    EXPECT_CALL(random, uuid()).Times(0);
     uuid_utils.set(request_headers, false, true);
-    EXPECT_EQ("first-request-id", request_headers.get_(Http::Headers::get().RequestId));
+    EXPECT_EQ(first_request_id, request_headers.get_(Http::Headers::get().RequestId));
   }
 }
 
 TEST(UUIDRequestIDExtensionTest, SetRequestIDWhenEmpty) {
-  testing::StrictMock<Random::MockRandomGenerator> random;
+  testing::NiceMock<Random::MockRandomGenerator> random;
+  Event::SimulatedTimeSystem time_system;
   UUIDRequestIDExtension uuid_utils(envoy::extensions::request_id::uuid::v3::UuidRequestIdConfig(),
-                                    random);
+                                    random, time_system);
 
   {
     // Request ID not set.
 
     Http::TestRequestHeaderMapImpl request_headers;
 
-    // A new request ID will be set.
-    EXPECT_CALL(random, uuid()).WillOnce(Return("first-request-id"));
+    // A new request ID will be set. generateUuidV7() calls random.random() twice.
     uuid_utils.set(request_headers, false, true);
-    EXPECT_EQ("first-request-id", request_headers.get_(Http::Headers::get().RequestId));
+    std::string first_request_id = std::string(request_headers.get_(Http::Headers::get().RequestId));
+    EXPECT_EQ(36, first_request_id.length());
+    EXPECT_EQ('f', first_request_id[0]); // UUIDv7 request_id marker
+    EXPECT_EQ('7', first_request_id[14]); // UUIDv7 version
   }
 
   {
@@ -109,10 +116,12 @@ TEST(UUIDRequestIDExtensionTest, SetRequestIDWhenEmpty) {
         "",
     }};
 
-    // A new request ID will be set.
-    EXPECT_CALL(random, uuid()).WillOnce(Return("first-request-id"));
+    // A new request ID will be set. generateUuidV7() calls random.random() twice.
     uuid_utils.set(request_headers, false, true);
-    EXPECT_EQ("first-request-id", request_headers.get_(Http::Headers::get().RequestId));
+    std::string first_request_id = std::string(request_headers.get_(Http::Headers::get().RequestId));
+    EXPECT_EQ(36, first_request_id.length());
+    EXPECT_EQ('f', first_request_id[0]);
+    EXPECT_EQ('7', first_request_id[14]);
   }
 
   {
@@ -124,7 +133,6 @@ TEST(UUIDRequestIDExtensionTest, SetRequestIDWhenEmpty) {
     }};
 
     // The request ID will be kept.
-    EXPECT_CALL(random, uuid()).Times(0);
     uuid_utils.set(request_headers, false, true);
     EXPECT_EQ("some-request-id", request_headers.get_(Http::Headers::get().RequestId));
   }
@@ -132,8 +140,9 @@ TEST(UUIDRequestIDExtensionTest, SetRequestIDWhenEmpty) {
 
 TEST(UUIDRequestIDExtensionTest, ClearExternalTraceReason) {
   testing::NiceMock<Random::MockRandomGenerator> random;
+  Event::SimulatedTimeSystem time_system;
   UUIDRequestIDExtension uuid_utils(envoy::extensions::request_id::uuid::v3::UuidRequestIdConfig(),
-                                    random);
+                                    random, time_system);
 
   std::string uuid_with_trace_reason = random.uuid_;
 
@@ -147,9 +156,8 @@ TEST(UUIDRequestIDExtensionTest, ClearExternalTraceReason) {
   }};
 
   std::string expected_uuid_with_trace_reason = uuid_with_trace_reason;
-  expected_uuid_with_trace_reason[14] = '4'; // 'b' means NO_TRACE.
+  expected_uuid_with_trace_reason[14] = '7'; // Clear to NO_TRACE (UUIDv7 version bit).
 
-  EXPECT_CALL(random, uuid()).Times(0);
   uuid_utils.set(request_headers, true, true);
 
   // External request ID will be kept but the trace reason will be cleared.
@@ -157,9 +165,10 @@ TEST(UUIDRequestIDExtensionTest, ClearExternalTraceReason) {
 }
 
 TEST(UUIDRequestIDExtensionTest, PreserveRequestIDInResponse) {
-  testing::StrictMock<Random::MockRandomGenerator> random;
+  testing::NiceMock<Random::MockRandomGenerator> random;
+  Event::SimulatedTimeSystem time_system;
   UUIDRequestIDExtension uuid_utils(envoy::extensions::request_id::uuid::v3::UuidRequestIdConfig(),
-                                    random);
+                                    random, time_system);
   Http::TestRequestHeaderMapImpl request_headers;
   Http::TestResponseHeaderMapImpl response_headers;
 
@@ -181,63 +190,77 @@ TEST(UUIDRequestIDExtensionTest, PreserveRequestIDInResponse) {
 }
 
 TEST(UUIDRequestIDExtensionTest, GetRequestIdAndModRequestIDBy) {
-  Random::RandomGeneratorImpl random;
+  testing::NiceMock<Random::MockRandomGenerator> random;
+  Event::SimulatedTimeSystem time_system;
   UUIDRequestIDExtension uuid_utils(envoy::extensions::request_id::uuid::v3::UuidRequestIdConfig(),
-                                    random);
+                                    random, time_system);
   Http::TestRequestHeaderMapImpl request_headers;
 
   EXPECT_FALSE(uuid_utils.get(request_headers));
   EXPECT_FALSE(uuid_utils.getInteger(request_headers).has_value());
 
+  // UUID too short (< 36 chars).
   request_headers.setRequestId("fffffff");
   EXPECT_EQ("fffffff", uuid_utils.get(request_headers).value());
   EXPECT_FALSE(uuid_utils.getInteger(request_headers).has_value());
 
-  request_headers.setRequestId("fffffffz-0012-0110-00ff-0c00400600ff");
-  EXPECT_EQ("fffffffz-0012-0110-00ff-0c00400600ff", uuid_utils.get(request_headers).value());
+  // UUID with invalid hex char 'z' in the last 8 chars (position 28-35).
+  request_headers.setRequestId("fffffffz-0012-0110-00ff-0c00400600fz");
+  EXPECT_EQ("fffffffz-0012-0110-00ff-0c00400600fz", uuid_utils.get(request_headers).value());
   EXPECT_FALSE(uuid_utils.getInteger(request_headers).has_value());
 
+  // getInteger() now uses last 8 hex chars (position 28-35).
+  // UUID: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+  //       0       8    13   18   23   28     35
+  //                                   ^^^^^^^^ (last 8 hex chars)
+
+  // "00000000-0000-0000-0000-000000000000" -> last 8 chars = "00000000" = 0
   request_headers.setRequestId("00000000-0000-0000-0000-000000000000");
   EXPECT_EQ("00000000-0000-0000-0000-000000000000", uuid_utils.get(request_headers).value());
   EXPECT_EQ(0, uuid_utils.getInteger(request_headers).value());
 
-  request_headers.setRequestId("00000001-0000-0000-0000-000000000000");
-  EXPECT_EQ("00000001-0000-0000-0000-000000000000", uuid_utils.get(request_headers).value());
+  // "00000001-0000-0000-0000-000000000001" -> last 8 chars = "00000001" = 1
+  request_headers.setRequestId("00000001-0000-0000-0000-000000000001");
+  EXPECT_EQ("00000001-0000-0000-0000-000000000001", uuid_utils.get(request_headers).value());
   EXPECT_EQ(1, uuid_utils.getInteger(request_headers).value());
 
-  request_headers.setRequestId("0000000f-0000-0000-0000-00000000000a");
-  EXPECT_EQ("0000000f-0000-0000-0000-00000000000a", uuid_utils.get(request_headers).value());
-  EXPECT_EQ(15, uuid_utils.getInteger(request_headers).value());
+  // "0000000f-0000-0000-0000-0000000000ff" -> last 8 chars = "000000ff" = 255
+  request_headers.setRequestId("0000000f-0000-0000-0000-0000000000ff");
+  EXPECT_EQ("0000000f-0000-0000-0000-0000000000ff", uuid_utils.get(request_headers).value());
+  EXPECT_EQ(255, uuid_utils.getInteger(request_headers).value());
 
   request_headers.setRequestId("");
   EXPECT_EQ("", uuid_utils.get(request_headers).value());
   EXPECT_FALSE(uuid_utils.getInteger(request_headers).has_value());
 
-  request_headers.setRequestId("000000ff-0000-0000-0000-000000000000");
-  EXPECT_EQ("000000ff-0000-0000-0000-000000000000", uuid_utils.get(request_headers).value());
-  EXPECT_EQ(55, uuid_utils.getInteger(request_headers).value() % 100);
+  // "000000ff-0000-0000-0000-000012345678" -> last 8 chars = "12345678" = 0x12345678
+  request_headers.setRequestId("000000ff-0000-0000-0000-000012345678");
+  EXPECT_EQ("000000ff-0000-0000-0000-000012345678", uuid_utils.get(request_headers).value());
+  EXPECT_EQ(0x12345678, uuid_utils.getInteger(request_headers).value());
 
-  request_headers.setRequestId("000000ff-0000-0000-0000-000000000000");
-  EXPECT_EQ("000000ff-0000-0000-0000-000000000000", uuid_utils.get(request_headers).value());
-  EXPECT_EQ(255, uuid_utils.getInteger(request_headers).value());
-
+  // "a0090100-0012-0110-00ff-0c00400600ff" -> last 8 chars = "400600ff" = 0x400600ff
   request_headers.setRequestId("a0090100-0012-0110-00ff-0c00400600ff");
   EXPECT_EQ("a0090100-0012-0110-00ff-0c00400600ff", uuid_utils.get(request_headers).value());
-  EXPECT_EQ(8, uuid_utils.getInteger(request_headers).value() % 137);
+  EXPECT_EQ(0x400600ff, uuid_utils.getInteger(request_headers).value());
 
+  // "ffffffff-0012-0110-00ff-0c00ffffffff" -> last 8 chars = "ffffffff" = 0xffffffff
+  request_headers.setRequestId("ffffffff-0012-0110-00ff-0c00ffffffff");
+  EXPECT_EQ("ffffffff-0012-0110-00ff-0c00ffffffff", uuid_utils.get(request_headers).value());
+  EXPECT_EQ(0xffffffff, uuid_utils.getInteger(request_headers).value());
+
+  // Test modulo operations for sampling distribution.
+  // "ffffffff-0012-0110-00ff-0c00400600ff" -> last 8 chars = "400600ff" = 0x400600ff = 1073873151
   request_headers.setRequestId("ffffffff-0012-0110-00ff-0c00400600ff");
   EXPECT_EQ("ffffffff-0012-0110-00ff-0c00400600ff", uuid_utils.get(request_headers).value());
-  EXPECT_EQ(95, uuid_utils.getInteger(request_headers).value() % 100);
-
-  request_headers.setRequestId("ffffffff-0012-0110-00ff-0c00400600ff");
-  EXPECT_EQ("ffffffff-0012-0110-00ff-0c00400600ff", uuid_utils.get(request_headers).value());
-  EXPECT_EQ(7295, uuid_utils.getInteger(request_headers).value() % 10000);
+  EXPECT_EQ(1073873151 % 100, uuid_utils.getInteger(request_headers).value() % 100);
+  EXPECT_EQ(1073873151 % 10000, uuid_utils.getInteger(request_headers).value() % 10000);
 }
 
 TEST(UUIDRequestIDExtensionTest, RequestIDModDistribution) {
   Random::RandomGeneratorImpl random;
+  Event::SimulatedTimeSystem time_system;
   UUIDRequestIDExtension uuid_utils(envoy::extensions::request_id::uuid::v3::UuidRequestIdConfig(),
-                                    random);
+                                    random, time_system);
   Http::TestRequestHeaderMapImpl request_headers;
 
   const int mod = 100;
@@ -246,13 +269,15 @@ TEST(UUIDRequestIDExtensionTest, RequestIDModDistribution) {
   int interesting_samples = 0;
 
   for (int i = 0; i < 500000; ++i) {
-    std::string uuid = random.uuid();
+    // Generate UUIDv7 via uuid_utils.set() instead of random.uuid().
+    uuid_utils.set(request_headers, true, false);
+    std::string uuid = std::string(request_headers.getRequestIdValue());
 
     const char c = uuid[19];
-    ASSERT_TRUE(uuid[14] == '4');                              // UUID version 4 (random)
+    ASSERT_TRUE(uuid[0] == 'f');                               // Request ID marker
+    ASSERT_TRUE(uuid[14] == '7');                              // UUID version 7
     ASSERT_TRUE(c == '8' || c == '9' || c == 'a' || c == 'b'); // UUID variant 1 (RFC4122)
 
-    request_headers.setRequestId(uuid);
     const uint64_t value = uuid_utils.getInteger(request_headers).value() % mod;
 
     if (value < required_percentage) {
@@ -266,18 +291,25 @@ TEST(UUIDRequestIDExtensionTest, RequestIDModDistribution) {
 
 TEST(UUIDRequestIDExtensionTest, DISABLED_benchmark) {
   Random::RandomGeneratorImpl random;
+  Event::SimulatedTimeSystem time_system;
+  UUIDRequestIDExtension uuid_utils(envoy::extensions::request_id::uuid::v3::UuidRequestIdConfig(),
+                                    random, time_system);
+  Http::TestRequestHeaderMapImpl request_headers;
 
   for (int i = 0; i < 100000000; ++i) {
-    random.uuid();
+    uuid_utils.set(request_headers, true, false);
   }
 }
 
 TEST(UUIDRequestIDExtensionTest, SetTraceStatus) {
   Random::RandomGeneratorImpl random;
+  Event::SimulatedTimeSystem time_system;
   UUIDRequestIDExtension uuid_utils(envoy::extensions::request_id::uuid::v3::UuidRequestIdConfig(),
-                                    random);
+                                    random, time_system);
   Http::TestRequestHeaderMapImpl request_headers;
-  request_headers.setRequestId(random.uuid());
+
+  // Generate UUIDv7 via uuid_utils.set() instead of random.uuid().
+  uuid_utils.set(request_headers, true, false);
 
   EXPECT_EQ(Tracing::Reason::NotTraceable, uuid_utils.getTraceReason(request_headers));
 
@@ -301,11 +333,15 @@ TEST(UUIDRequestIDExtensionTest, SetTraceStatus) {
 
 TEST(UUIDRequestIDExtensionTest, SetTraceStatusPackingDisabled) {
   Random::RandomGeneratorImpl random;
+  Event::SimulatedTimeSystem time_system;
   envoy::extensions::request_id::uuid::v3::UuidRequestIdConfig config;
   config.mutable_pack_trace_reason()->set_value(false);
-  UUIDRequestIDExtension uuid_utils(config, random);
+  UUIDRequestIDExtension uuid_utils(config, random, time_system);
 
-  std::string uuid_with_trace_reason = random.uuid();
+  // Generate UUIDv7 and manually set trace reason marker.
+  Http::TestRequestHeaderMapImpl temp_headers;
+  uuid_utils.set(temp_headers, true, false);
+  std::string uuid_with_trace_reason = std::string(temp_headers.getRequestIdValue());
   uuid_with_trace_reason[14] = 'b'; // 'b' means TRACE_CLIENT.
 
   Http::TestRequestHeaderMapImpl request_headers;
@@ -317,6 +353,38 @@ TEST(UUIDRequestIDExtensionTest, SetTraceStatusPackingDisabled) {
   uuid_utils.setTraceReason(request_headers, Tracing::Reason::Sampling);
   EXPECT_EQ(Tracing::Reason::NotTraceable, uuid_utils.getTraceReason(request_headers));
   EXPECT_EQ(uuid_with_trace_reason, request_headers.getRequestIdValue());
+}
+
+TEST(UUIDRequestIDExtensionTest, GenerateUuidV7Format) {
+  testing::NiceMock<Random::MockRandomGenerator> random;
+  Event::SimulatedTimeSystem time_system;
+  UUIDRequestIDExtension uuid_utils(
+      envoy::extensions::request_id::uuid::v3::UuidRequestIdConfig(), random, time_system);
+
+  Http::TestRequestHeaderMapImpl request_headers;
+
+  EXPECT_CALL(random, random()).Times(2).WillRepeatedly(Return(0x123456789ABCDEFULL));
+  uuid_utils.set(request_headers, true, false);
+
+  std::string uuid = std::string(request_headers.getRequestIdValue());
+
+  // Verify UUID length.
+  EXPECT_EQ(36, uuid.length());
+
+  // Verify marker: request_id starts with 'f'.
+  EXPECT_EQ('f', uuid[0]);
+
+  // Verify version: position 14 = '7' (UUIDv7).
+  EXPECT_EQ('7', uuid[14]);
+
+  // Verify variant: position 19 = '8', '9', 'a', or 'b' (RFC 4122).
+  EXPECT_TRUE(uuid[19] == '8' || uuid[19] == '9' || uuid[19] == 'a' || uuid[19] == 'b');
+
+  // Verify UUID format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+  EXPECT_EQ('-', uuid[8]);
+  EXPECT_EQ('-', uuid[13]);
+  EXPECT_EQ('-', uuid[18]);
+  EXPECT_EQ('-', uuid[23]);
 }
 
 } // namespace RequestId

--- a/test/extensions/tracers/opentelemetry/opentelemetry_tracer_impl_test.cc
+++ b/test/extensions/tracers/opentelemetry/opentelemetry_tracer_impl_test.cc
@@ -252,18 +252,20 @@ TEST_F(OpenTelemetryDriverTest, GenerateSpanContextWithoutHeadersTest) {
   Tracing::TestTraceContextImpl request_headers{
       {":authority", "test.com"}, {":path", "/"}, {":method", "GET"}};
 
-  // Mock the random call for generating trace and span IDs so we can check it later.
-  const uint64_t trace_id_high = 1;
-  const uint64_t trace_id_low = 2;
+  // Fix timestamp for deterministic UUIDv7 trace_id generation.
+  time_system_.setSystemTime(std::chrono::milliseconds(0));
+
+  // Mock the random calls for generating trace_id (UUIDv7: rand_a, rand_b) and span_id.
+  const uint64_t rand_a = 1;
+  const uint64_t rand_b = 2;
   const uint64_t new_span_id = 3;
   NiceMock<Random::MockRandomGenerator>& mock_random_generator_ =
       context_.server_factory_context_.api_.random_;
-  // The tracer should generate three random numbers for the trace high, trace low, and span id.
   {
     InSequence s;
 
-    EXPECT_CALL(mock_random_generator_, random()).WillOnce(Return(trace_id_high));
-    EXPECT_CALL(mock_random_generator_, random()).WillOnce(Return(trace_id_low));
+    EXPECT_CALL(mock_random_generator_, random()).WillOnce(Return(rand_a));
+    EXPECT_CALL(mock_random_generator_, random()).WillOnce(Return(rand_b));
     EXPECT_CALL(mock_random_generator_, random()).WillOnce(Return(new_span_id));
   }
 
@@ -278,8 +280,9 @@ TEST_F(OpenTelemetryDriverTest, GenerateSpanContextWithoutHeadersTest) {
 
   // Ends in 01 because span should be sampled. See
   // https://w3c.github.io/trace-context/#trace-flags.
+  // trace_id is UUIDv7: timestamp(0) + version(7) + rand_a(1) | variant(2) + rand_b(2)
   EXPECT_EQ(sampled_entry.has_value(), true);
-  EXPECT_EQ(sampled_entry.value(), "00-00000000000000010000000000000002-0000000000000003-01");
+  EXPECT_EQ(sampled_entry.value(), "00-00000000000070018000000000000002-0000000000000003-01");
 }
 
 // Verifies a span it not created when an invalid traceparent header is received
@@ -606,6 +609,8 @@ TEST_F(OpenTelemetryDriverTest, ExportOTLPSpanWithAttributes) {
   setupValidDriver();
   Tracing::TestTraceContextImpl request_headers{
       {":authority", "test.com"}, {":path", "/"}, {":method", "GET"}};
+  // Fix timestamp for deterministic UUIDv7 trace_id generation.
+  time_system_.setSystemTime(std::chrono::milliseconds(0));
   NiceMock<Random::MockRandomGenerator>& mock_random_generator_ =
       context_.server_factory_context_.api_.random_;
   int64_t generated_int = 1;
@@ -660,12 +665,11 @@ resource_spans:
 
   TestUtility::loadFromYaml(fmt::format(request_yaml, envoy_version, timestamp_ns, timestamp_ns),
                             request_proto);
-  std::string generated_int_hex = Hex::uint64ToHex(generated_int);
   auto* expected_span =
       request_proto.mutable_resource_spans(0)->mutable_scope_spans(0)->mutable_spans(0);
-  expected_span->set_trace_id(
-      absl::HexStringToBytes(absl::StrCat(generated_int_hex, generated_int_hex)));
-  expected_span->set_span_id(absl::HexStringToBytes(absl::StrCat(generated_int_hex)));
+  // UUIDv7 trace_id: timestamp(0) + version(7) + rand_a(1) | variant(2) + rand_b(1)
+  expected_span->set_trace_id(absl::HexStringToBytes("00000000000070018000000000000001"));
+  expected_span->set_span_id(absl::HexStringToBytes(Hex::uint64ToHex(generated_int)));
 
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.opentelemetry.min_flush_spans", 5U))
       .Times(1)
@@ -753,6 +757,8 @@ TEST_F(OpenTelemetryDriverTest, ExportOTLPSpanWithAttributesAndStatus) {
   setupValidDriver();
   Tracing::TestTraceContextImpl request_headers{
       {":authority", "test.com"}, {":path", "/"}, {":method", "GET"}};
+  // Fix timestamp for deterministic UUIDv7 trace_id generation.
+  time_system_.setSystemTime(std::chrono::milliseconds(0));
   NiceMock<Random::MockRandomGenerator>& mock_random_generator_ =
       context_.server_factory_context_.api_.random_;
   int64_t generated_int = 1;
@@ -813,12 +819,11 @@ resource_spans:
 
   TestUtility::loadFromYaml(fmt::format(request_yaml, envoy_version, timestamp_ns, timestamp_ns),
                             request_proto);
-  std::string generated_int_hex = Hex::uint64ToHex(generated_int);
   auto* expected_span =
       request_proto.mutable_resource_spans(0)->mutable_scope_spans(0)->mutable_spans(0);
-  expected_span->set_trace_id(
-      absl::HexStringToBytes(absl::StrCat(generated_int_hex, generated_int_hex)));
-  expected_span->set_span_id(absl::HexStringToBytes(absl::StrCat(generated_int_hex)));
+  // UUIDv7 trace_id: timestamp(0) + version(7) + rand_a(1) | variant(2) + rand_b(1)
+  expected_span->set_trace_id(absl::HexStringToBytes("00000000000070018000000000000001"));
+  expected_span->set_span_id(absl::HexStringToBytes(Hex::uint64ToHex(generated_int)));
 
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.opentelemetry.min_flush_spans", 5U))
       .Times(1)
@@ -835,6 +840,8 @@ TEST_F(OpenTelemetryDriverTest, ExportOTLPGRPCSpanWithAttributesAndStatus) {
   setupValidDriver();
   Tracing::TestTraceContextImpl request_headers{
       {":authority", "test.com"}, {":path", "/"}, {":method", "GET"}};
+  // Fix timestamp for deterministic UUIDv7 trace_id generation.
+  time_system_.setSystemTime(std::chrono::milliseconds(0));
   NiceMock<Random::MockRandomGenerator>& mock_random_generator_ =
       context_.server_factory_context_.api_.random_;
   int64_t generated_int = 1;
@@ -903,12 +910,11 @@ resource_spans:
 
   TestUtility::loadFromYaml(fmt::format(request_yaml, envoy_version, timestamp_ns, timestamp_ns),
                             request_proto);
-  std::string generated_int_hex = Hex::uint64ToHex(generated_int);
   auto* expected_span =
       request_proto.mutable_resource_spans(0)->mutable_scope_spans(0)->mutable_spans(0);
-  expected_span->set_trace_id(
-      absl::HexStringToBytes(absl::StrCat(generated_int_hex, generated_int_hex)));
-  expected_span->set_span_id(absl::HexStringToBytes(absl::StrCat(generated_int_hex)));
+  // UUIDv7 trace_id: timestamp(0) + version(7) + rand_a(1) | variant(2) + rand_b(1)
+  expected_span->set_trace_id(absl::HexStringToBytes("00000000000070018000000000000001"));
+  expected_span->set_span_id(absl::HexStringToBytes(Hex::uint64ToHex(generated_int)));
 
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.opentelemetry.min_flush_spans", 5U))
       .Times(1)
@@ -1018,6 +1024,8 @@ TEST_F(OpenTelemetryDriverTest, ExportSpanWithCustomServiceName) {
 
   Tracing::TestTraceContextImpl request_headers{
       {":authority", "test.com"}, {":path", "/"}, {":method", "GET"}};
+  // Fix timestamp for deterministic UUIDv7 trace_id generation.
+  time_system_.setSystemTime(std::chrono::milliseconds(0));
   NiceMock<Random::MockRandomGenerator>& mock_random_generator_ =
       context_.server_factory_context_.api_.random_;
   int64_t generated_int = 1;
@@ -1057,12 +1065,11 @@ resource_spans:
 
   TestUtility::loadFromYaml(fmt::format(request_yaml, envoy_version, timestamp_ns, timestamp_ns),
                             request_proto);
-  std::string generated_int_hex = Hex::uint64ToHex(generated_int);
   auto* expected_span =
       request_proto.mutable_resource_spans(0)->mutable_scope_spans(0)->mutable_spans(0);
-  expected_span->set_trace_id(
-      absl::HexStringToBytes(absl::StrCat(generated_int_hex, generated_int_hex)));
-  expected_span->set_span_id(absl::HexStringToBytes(absl::StrCat(generated_int_hex)));
+  // UUIDv7 trace_id: timestamp(0) + version(7) + rand_a(1) | variant(2) + rand_b(1)
+  expected_span->set_trace_id(absl::HexStringToBytes("00000000000070018000000000000001"));
+  expected_span->set_span_id(absl::HexStringToBytes(Hex::uint64ToHex(generated_int)));
 
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.opentelemetry.min_flush_spans", 5U))
       .Times(1)

--- a/test/extensions/tracers/opentelemetry/samplers/always_on/always_on_sampler_integration_test.cc
+++ b/test/extensions/tracers/opentelemetry/samplers/always_on/always_on_sampler_integration_test.cc
@@ -59,9 +59,12 @@ INSTANTIATE_TEST_SUITE_P(IpVersions, AlwaysOnSamplerIntegrationTest,
 
 // Sends a request with traceparent and tracestate header.
 TEST_P(AlwaysOnSamplerIntegrationTest, TestWithTraceparentAndTracestate) {
-  Http::TestRequestHeaderMapImpl request_headers{
-      {":method", "GET"},     {":path", "/test/long/url"}, {":scheme", "http"},
-      {":authority", "host"}, {"tracestate", "key=value"}, {"traceparent", TRACEPARENT_VALUE}};
+  Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"},
+                                                 {":path", "/test/long/url"},
+                                                 {":scheme", "http"},
+                                                 {":authority", "host"},
+                                                 {"x-sendbird-tracestate", "key=value"},
+                                                 {"x-sendbird-traceparent", TRACEPARENT_VALUE}};
 
   auto response = sendRequestAndWaitForResponse(request_headers, 0, default_response_headers_, 0);
 
@@ -71,14 +74,14 @@ TEST_P(AlwaysOnSamplerIntegrationTest, TestWithTraceparentAndTracestate) {
 
   // traceparent should be set: traceid should be re-used, span id should be different
   absl::string_view traceparent_value = upstream_request_->headers()
-                                            .get(Http::LowerCaseString("traceparent"))[0]
+                                            .get(Http::LowerCaseString("x-sendbird-traceparent"))[0]
                                             ->value()
                                             .getStringView();
   EXPECT_TRUE(absl::StartsWith(traceparent_value, TRACEPARENT_VALUE_START));
   EXPECT_NE(TRACEPARENT_VALUE, traceparent_value);
   // tracestate should be forwarded
   absl::string_view tracestate_value = upstream_request_->headers()
-                                           .get(Http::LowerCaseString("tracestate"))[0]
+                                           .get(Http::LowerCaseString("x-sendbird-tracestate"))[0]
                                            ->value()
                                            .getStringView();
   EXPECT_EQ("key=value", tracestate_value);
@@ -90,7 +93,7 @@ TEST_P(AlwaysOnSamplerIntegrationTest, TestWithTraceparentOnly) {
                                                  {":path", "/test/long/url"},
                                                  {":scheme", "http"},
                                                  {":authority", "host"},
-                                                 {"traceparent", TRACEPARENT_VALUE}};
+                                                 {"x-sendbird-traceparent", TRACEPARENT_VALUE}};
   auto response = sendRequestAndWaitForResponse(request_headers, 0, default_response_headers_, 0);
 
   ASSERT_TRUE(response->waitForEndStream());
@@ -99,14 +102,14 @@ TEST_P(AlwaysOnSamplerIntegrationTest, TestWithTraceparentOnly) {
 
   // traceparent should be set: traceid should be re-used, span id should be different
   absl::string_view traceparent_value = upstream_request_->headers()
-                                            .get(Http::LowerCaseString("traceparent"))[0]
+                                            .get(Http::LowerCaseString("x-sendbird-traceparent"))[0]
                                             ->value()
                                             .getStringView();
   EXPECT_TRUE(absl::StartsWith(traceparent_value, TRACEPARENT_VALUE_START));
   EXPECT_NE(TRACEPARENT_VALUE, traceparent_value);
   // OTLP tracer adds an empty tracestate
   absl::string_view tracestate_value = upstream_request_->headers()
-                                           .get(Http::LowerCaseString("tracestate"))[0]
+                                           .get(Http::LowerCaseString("x-sendbird-tracestate"))[0]
                                            ->value()
                                            .getStringView();
   EXPECT_EQ("", tracestate_value);
@@ -125,11 +128,13 @@ TEST_P(AlwaysOnSamplerIntegrationTest, TestWithoutTraceparentAndTracestate) {
 
   // traceparent will be added, trace_id and span_id will be generated, so there is nothing we can
   // assert
-  EXPECT_EQ(upstream_request_->headers().get(::Envoy::Http::LowerCaseString("traceparent")).size(),
+  EXPECT_EQ(upstream_request_->headers()
+                .get(::Envoy::Http::LowerCaseString("x-sendbird-traceparent"))
+                .size(),
             1);
   // OTLP tracer adds an empty tracestate
   absl::string_view tracestate_value = upstream_request_->headers()
-                                           .get(Http::LowerCaseString("tracestate"))[0]
+                                           .get(Http::LowerCaseString("x-sendbird-tracestate"))[0]
                                            ->value()
                                            .getStringView();
   EXPECT_EQ("", tracestate_value);

--- a/test/extensions/tracers/opentelemetry/samplers/dynatrace/dynatrace_sampler_integration_test.cc
+++ b/test/extensions/tracers/opentelemetry/samplers/dynatrace/dynatrace_sampler_integration_test.cc
@@ -61,9 +61,12 @@ INSTANTIATE_TEST_SUITE_P(IpVersions, DynatraceSamplerIntegrationTest,
 // Sends a request with traceparent and tracestate header.
 TEST_P(DynatraceSamplerIntegrationTest, TestWithTraceparentAndTracestate) {
   // tracestate does not contain a Dynatrace tag
-  Http::TestRequestHeaderMapImpl request_headers{
-      {":method", "GET"},     {":path", "/test/long/url"}, {":scheme", "http"},
-      {":authority", "host"}, {"tracestate", "key=value"}, {"traceparent", TRACEPARENT_VALUE}};
+  Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"},
+                                                 {":path", "/test/long/url"},
+                                                 {":scheme", "http"},
+                                                 {":authority", "host"},
+                                                 {"x-sendbird-tracestate", "key=value"},
+                                                 {"x-sendbird-traceparent", TRACEPARENT_VALUE}};
 
   auto response = sendRequestAndWaitForResponse(request_headers, 0, default_response_headers_, 0);
 
@@ -73,14 +76,14 @@ TEST_P(DynatraceSamplerIntegrationTest, TestWithTraceparentAndTracestate) {
 
   // traceparent should be set: traceid should be re-used, span id should be different
   absl::string_view traceparent_value = upstream_request_->headers()
-                                            .get(Http::LowerCaseString("traceparent"))[0]
+                                            .get(Http::LowerCaseString("x-sendbird-traceparent"))[0]
                                             ->value()
                                             .getStringView();
   EXPECT_TRUE(absl::StartsWith(traceparent_value, TRACEPARENT_VALUE_START));
   EXPECT_NE(TRACEPARENT_VALUE, traceparent_value);
   // Dynatrace tracestate should be added to existing tracestate
   absl::string_view tracestate_value = upstream_request_->headers()
-                                           .get(Http::LowerCaseString("tracestate"))[0]
+                                           .get(Http::LowerCaseString("x-sendbird-tracestate"))[0]
                                            ->value()
                                            .getStringView();
   // use StartsWith because path-info (last element in trace state) contains a random value
@@ -98,7 +101,7 @@ TEST_P(DynatraceSamplerIntegrationTest, TestWithTraceparentOnly) {
                                                  {":path", "/test/long/url"},
                                                  {":scheme", "http"},
                                                  {":authority", "host"},
-                                                 {"traceparent", TRACEPARENT_VALUE}};
+                                                 {"x-sendbird-traceparent", TRACEPARENT_VALUE}};
   auto response = sendRequestAndWaitForResponse(request_headers, 0, default_response_headers_, 0);
 
   ASSERT_TRUE(response->waitForEndStream());
@@ -107,14 +110,14 @@ TEST_P(DynatraceSamplerIntegrationTest, TestWithTraceparentOnly) {
 
   // traceparent should be set: traceid should be re-used, span id should be different
   absl::string_view traceparent_value = upstream_request_->headers()
-                                            .get(Http::LowerCaseString("traceparent"))[0]
+                                            .get(Http::LowerCaseString("x-sendbird-traceparent"))[0]
                                             ->value()
                                             .getStringView();
   EXPECT_TRUE(absl::StartsWith(traceparent_value, TRACEPARENT_VALUE_START));
   EXPECT_NE(TRACEPARENT_VALUE, traceparent_value);
   // Dynatrace tag should be added to tracestate
   absl::string_view tracestate_value = upstream_request_->headers()
-                                           .get(Http::LowerCaseString("tracestate"))[0]
+                                           .get(Http::LowerCaseString("x-sendbird-tracestate"))[0]
                                            ->value()
                                            .getStringView();
   // use StartsWith because path-info (last element in trace state contains a random value)
@@ -137,11 +140,13 @@ TEST_P(DynatraceSamplerIntegrationTest, TestWithoutTraceparentAndTracestate) {
 
   // traceparent will be added, trace_id and span_id will be generated, so there is nothing we can
   // assert
-  EXPECT_EQ(upstream_request_->headers().get(::Envoy::Http::LowerCaseString("traceparent")).size(),
+  EXPECT_EQ(upstream_request_->headers()
+                .get(::Envoy::Http::LowerCaseString("x-sendbird-traceparent"))
+                .size(),
             1);
   // Dynatrace tag should be added to tracestate
   absl::string_view tracestate_value = upstream_request_->headers()
-                                           .get(Http::LowerCaseString("tracestate"))[0]
+                                           .get(Http::LowerCaseString("x-sendbird-tracestate"))[0]
                                            ->value()
                                            .getStringView();
   EXPECT_TRUE(absl::StartsWith(tracestate_value, "5b3f9fed-980df25c@dt=fw4;0;0;0;0;0;0;"))

--- a/test/extensions/tracers/opentelemetry/span_context_extractor_test.cc
+++ b/test/extensions/tracers/opentelemetry/span_context_extractor_test.cc
@@ -23,7 +23,8 @@ constexpr absl::string_view trace_flags = "01";
 
 TEST(SpanContextExtractorTest, ExtractSpanContext) {
   Tracing::TestTraceContextImpl request_headers{
-      {"traceparent", fmt::format("{}-{}-{}-{}", version, trace_id, parent_id, trace_flags)}};
+      {"x-sendbird-traceparent",
+       fmt::format("{}-{}-{}-{}", version, trace_id, parent_id, trace_flags)}};
 
   SpanContextExtractor span_context_extractor(request_headers);
   absl::StatusOr<SpanContext> span_context = span_context_extractor.extractSpanContext();
@@ -38,7 +39,7 @@ TEST(SpanContextExtractorTest, ExtractSpanContext) {
 TEST(SpanContextExtractorTest, ExtractSpanContextNotSampled) {
   const std::string trace_flags_unsampled{"00"};
   Tracing::TestTraceContextImpl request_headers{
-      {"traceparent",
+      {"x-sendbird-traceparent",
        fmt::format("{}-{}-{}-{}", version, trace_id, parent_id, trace_flags_unsampled)}};
   SpanContextExtractor span_context_extractor(request_headers);
   absl::StatusOr<SpanContext> span_context = span_context_extractor.extractSpanContext();
@@ -62,7 +63,8 @@ TEST(SpanContextExtractorTest, ThrowsExceptionWithoutHeader) {
 
 TEST(SpanContextExtractorTest, ThrowsExceptionWithTooLongHeader) {
   Tracing::TestTraceContextImpl request_headers{
-      {"traceparent", fmt::format("000{}-{}-{}-{}", version, trace_id, parent_id, trace_flags)}};
+      {"x-sendbird-traceparent",
+       fmt::format("000{}-{}-{}-{}", version, trace_id, parent_id, trace_flags)}};
   SpanContextExtractor span_context_extractor(request_headers);
 
   absl::StatusOr<SpanContext> span_context = span_context_extractor.extractSpanContext();
@@ -73,7 +75,7 @@ TEST(SpanContextExtractorTest, ThrowsExceptionWithTooLongHeader) {
 
 TEST(SpanContextExtractorTest, ThrowsExceptionWithTooShortHeader) {
   Tracing::TestTraceContextImpl request_headers{
-      {"traceparent", fmt::format("{}-{}-{}", trace_id, parent_id, trace_flags)}};
+      {"x-sendbird-traceparent", fmt::format("{}-{}-{}", trace_id, parent_id, trace_flags)}};
   SpanContextExtractor span_context_extractor(request_headers);
 
   absl::StatusOr<SpanContext> span_context = span_context_extractor.extractSpanContext();
@@ -84,7 +86,8 @@ TEST(SpanContextExtractorTest, ThrowsExceptionWithTooShortHeader) {
 
 TEST(SpanContextExtractorTest, ThrowsExceptionWithInvalidHyphenation) {
   Tracing::TestTraceContextImpl request_headers{
-      {"traceparent", fmt::format("{}{}-{}-{}", version, trace_id, parent_id, trace_flags)}};
+      {"x-sendbird-traceparent",
+       fmt::format("{}{}-{}-{}", version, trace_id, parent_id, trace_flags)}};
   SpanContextExtractor span_context_extractor(request_headers);
 
   absl::StatusOr<SpanContext> span_context = span_context_extractor.extractSpanContext();
@@ -97,7 +100,7 @@ TEST(SpanContextExtractorTest, ThrowsExceptionWithInvalidSizes) {
   const std::string invalid_version{"0"};
   const std::string invalid_trace_flags{"001"};
   Tracing::TestTraceContextImpl request_headers{
-      {"traceparent",
+      {"x-sendbird-traceparent",
        fmt::format("{}-{}-{}-{}", invalid_version, trace_id, parent_id, invalid_trace_flags)}};
   SpanContextExtractor span_context_extractor(request_headers);
 
@@ -110,7 +113,7 @@ TEST(SpanContextExtractorTest, ThrowsExceptionWithInvalidSizes) {
 TEST(SpanContextExtractorTest, ThrowsExceptionWithInvalidHex) {
   const std::string invalid_version{"ZZ"};
   Tracing::TestTraceContextImpl request_headers{
-      {"traceparent",
+      {"x-sendbird-traceparent",
        fmt::format("{}-{}-{}-{}", invalid_version, trace_id, parent_id, trace_flags)}};
   SpanContextExtractor span_context_extractor(request_headers);
 
@@ -123,7 +126,7 @@ TEST(SpanContextExtractorTest, ThrowsExceptionWithInvalidHex) {
 TEST(SpanContextExtractorTest, ThrowsExceptionWithAllZeroTraceId) {
   const std::string invalid_trace_id{"00000000000000000000000000000000"};
   Tracing::TestTraceContextImpl request_headers{
-      {"traceparent",
+      {"x-sendbird-traceparent",
        fmt::format("{}-{}-{}-{}", version, invalid_trace_id, parent_id, trace_flags)}};
   SpanContextExtractor span_context_extractor(request_headers);
 
@@ -136,7 +139,7 @@ TEST(SpanContextExtractorTest, ThrowsExceptionWithAllZeroTraceId) {
 TEST(SpanContextExtractorTest, ThrowsExceptionWithAllZeroParentId) {
   const std::string invalid_parent_id{"0000000000000000"};
   Tracing::TestTraceContextImpl request_headers{
-      {"traceparent",
+      {"x-sendbird-traceparent",
        fmt::format("{}-{}-{}-{}", version, trace_id, invalid_parent_id, trace_flags)}};
   SpanContextExtractor span_context_extractor(request_headers);
 
@@ -148,7 +151,8 @@ TEST(SpanContextExtractorTest, ThrowsExceptionWithAllZeroParentId) {
 
 TEST(SpanContextExtractorTest, ExtractSpanContextWithEmptyTracestate) {
   Tracing::TestTraceContextImpl request_headers{
-      {"traceparent", fmt::format("{}-{}-{}-{}", version, trace_id, parent_id, trace_flags)}};
+      {"x-sendbird-traceparent",
+       fmt::format("{}-{}-{}-{}", version, trace_id, parent_id, trace_flags)}};
   SpanContextExtractor span_context_extractor(request_headers);
   absl::StatusOr<SpanContext> span_context = span_context_extractor.extractSpanContext();
 
@@ -158,8 +162,9 @@ TEST(SpanContextExtractorTest, ExtractSpanContextWithEmptyTracestate) {
 
 TEST(SpanContextExtractorTest, ExtractSpanContextWithTracestate) {
   Tracing::TestTraceContextImpl request_headers{
-      {"traceparent", fmt::format("{}-{}-{}-{}", version, trace_id, parent_id, trace_flags)},
-      {"tracestate", "sample-tracestate"}};
+      {"x-sendbird-traceparent",
+       fmt::format("{}-{}-{}-{}", version, trace_id, parent_id, trace_flags)},
+      {"x-sendbird-tracestate", "sample-tracestate"}};
   SpanContextExtractor span_context_extractor(request_headers);
   absl::StatusOr<SpanContext> span_context = span_context_extractor.extractSpanContext();
 
@@ -168,7 +173,7 @@ TEST(SpanContextExtractorTest, ExtractSpanContextWithTracestate) {
 }
 
 TEST(SpanContextExtractorTest, IgnoreTracestateWithoutTraceparent) {
-  Tracing::TestTraceContextImpl request_headers{{"tracestate", "sample-tracestate"}};
+  Tracing::TestTraceContextImpl request_headers{{"x-sendbird-tracestate", "sample-tracestate"}};
   SpanContextExtractor span_context_extractor(request_headers);
   absl::StatusOr<SpanContext> span_context = span_context_extractor.extractSpanContext();
 
@@ -178,9 +183,10 @@ TEST(SpanContextExtractorTest, IgnoreTracestateWithoutTraceparent) {
 
 TEST(SpanContextExtractorTest, ExtractSpanContextWithMultipleTracestateEntries) {
   Http::TestRequestHeaderMapImpl request_headers{
-      {"traceparent", fmt::format("{}-{}-{}-{}", version, trace_id, parent_id, trace_flags)},
-      {"tracestate", "sample-tracestate"},
-      {"tracestate", "sample-tracestate-2"}};
+      {"x-sendbird-traceparent",
+       fmt::format("{}-{}-{}-{}", version, trace_id, parent_id, trace_flags)},
+      {"x-sendbird-tracestate", "sample-tracestate"},
+      {"x-sendbird-tracestate", "sample-tracestate-2"}};
   Tracing::HttpTraceContext trace_context(request_headers);
   SpanContextExtractor span_context_extractor(trace_context);
   absl::StatusOr<SpanContext> span_context = span_context_extractor.extractSpanContext();


### PR DESCRIPTION
JIRA: https://sendbird.atlassian.net/browse/CPLAT-10838

## Summary
Update Sendbird Envoy fork to upstream v1.38.3 and cherry-pick the 10 Sendbird custom patches not in upstream.

## Sendbird patches cherry-picked (not upstreamed)
- redis: per-shard Redis proxy metrics (enable_per_shard_stats / enable_per_shard_latency_stats)
- redis: race-condition / use-after-free fix in cluster destruction
- redis: eval_ro / evalsha_ro support
- redis: pubsub commands
- QUIC keylog support (SSLKEYLOGFILE + TLS context integration)
- custom tracing header
- trace_id pattern (UUIDv4 -> UUIDv7)
- request_id format (UUIDv4 -> custom UUIDv7) + TRACE_SAMPLED access log formatter
- TraceSampledFormatter adaptation to v1.37 formatter API

## Already in upstream v1.38.3 (not re-ported)
- redis zone-aware routing (enable_zone_discovery, LOCAL_ZONE_AFFINITY / LOCAL_ZONE_AFFINITY_REPLICAS_AND_PRIMARY) — upstreamed as envoyproxy/envoy#43012 by the same author. Config enum renamed from old sendbird az_affinity to LOCAL_ZONE_AFFINITY; verify downstream configs if used.

## Fixes in this PR
- Remove a leftover diff3 conflict marker in test/extensions/clusters/redis/redis_cluster_lb_test.cc left by the eval_ro cherry-pick. The marker had also dropped the closing brace of the LocalZoneAffinityEmptyClientZone test, breaking compilation. Restored the closing brace and a blank line so both the zone-aware and ReadOnlyCommand tests are well-formed (brace balance 235/235).

## Test Plan
- [ ] make build_envoy (release)
- [ ] make build_envoy_debug
- [ ] make test — especially //test/extensions/clusters/redis/... and //test/extensions/filters/network/redis_proxy/...
- [ ] Verify compatibility with Istio 1.30.2 proxy-istio build

## Related
- proxy-istio ENVOY_SHA references 3989f616c6 (ancestor of this PR HEAD). The conflict-marker fix is test-only, so the produced Envoy binary is unchanged; no ENVOY_SHA256 bump required on the proxy-istio side.
